### PR TITLE
use a lowercase module name

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/Nullify-Platform/Logger/pkg/logger"
+import "github.com/nullify-platform/Logger/pkg/logger"
 
 func main() {
 	log, err := logger.ConfigureProductionLogger("info")

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Nullify-Platform/Logger
+module github.com/nullify-platform/Logger
 
 go 1.19
 


### PR DESCRIPTION
## Description

Use a lowercase module name since it seems to be the convention.

## Linked issues

- None

## Checklist

- [x] I have add the `breaking change` or `feature` label if they are required
- [x] I have performed a self-review of my own code
- [x] I have checked for redundant or commented out code
- [x] I have commented my code where I can't make it self-documenting
- [x] I have made corresponding changes to the documentation
- [x] I have added any appropriate tests

