### PR TITLE
add caller info, adding new default fields and unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ clean:
 format: 
 	gofmt -w ./...
 
+unit:
+	go test ./...
+
 cov:
 	-go test -coverpkg=./... -coverprofile=coverage.txt -covermode count ./...
 	-gocover-cobertura < coverage.txt > coverage.xml

--- a/go.mod
+++ b/go.mod
@@ -7,9 +7,14 @@ require (
 	go.uber.org/multierr v1.8.0 // indirect
 )
 
-require github.com/pkg/errors v0.9.1 // indirect
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)
 
 require (
-	github.com/stretchr/testify v1.8.1 // indirect
+	github.com/stretchr/testify v1.8.1
 	go.uber.org/zap v1.24.0
 )

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,7 @@ go.uber.org/multierr v1.8.0 h1:dg6GjLku4EH+249NNmoIciG9N/jURbDG+pFlTkhzIC8=
 go.uber.org/multierr v1.8.0/go.mod h1:7EAYxJLBy9rStEaz58O2t4Uvip6FSURkq8/ppBp95ak=
 go.uber.org/zap v1.24.0 h1:FiJd5l1UOLj0wCgbSE0rwwXHzEdAZS6hiiSnxJN/D60=
 go.uber.org/zap v1.24.0/go.mod h1:2kMP+WWQ8aoFoedH3T2sq6iJ2yDWpHbP0f6MQbS9Gkg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/logger/fields.go
+++ b/pkg/logger/fields.go
@@ -1,0 +1,38 @@
+package logger
+
+import (
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// Fields
+
+func Trace(trace []byte) zapcore.Field {
+	return zap.ByteString("trace", trace)
+}
+
+func Err(err error) zapcore.Field {
+	return zap.Error(err)
+}
+
+func Any(key string, val interface{}) zapcore.Field {
+	return zap.Any(key, val)
+}
+
+func String(key string, val string) zapcore.Field {
+	return zap.String(key, val)
+}
+
+func Int(key string, val int) zapcore.Field {
+	return zap.Int(key, val)
+}
+
+func Int64(key string, val int64) zapcore.Field {
+	return zap.Int64(key, val)
+}
+
+func Duration(key string, val time.Duration) zapcore.Field {
+	return zap.Duration(key, val)
+}

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,8 +1,8 @@
 package logger
 
 import (
+	"io"
 	"os"
-	"time"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -23,87 +23,53 @@ func (logger syncLogger) Sync() {
 	logger.SyncImplementation()
 }
 
-func ConfigureDevelopmentLogger(level string) (Logger, error) {
+func ConfigureDevelopmentLogger(level string, syncs ...io.Writer) (Logger, error) {
 	// configure level
 	zapLevel, err := zapcore.ParseLevel(level)
 	if err != nil {
 		zap.L().Fatal("failed to parse log level")
 	}
 
+	var sync io.Writer = os.Stdout
+	if len(syncs) > 0 {
+		sync = syncs[0]
+	}
+
 	logger := zap.New(zapcore.NewCore(
 		zapcore.NewConsoleEncoder(zap.NewDevelopmentEncoderConfig()),
-		zapcore.AddSync(os.Stdout),
+		zapcore.AddSync(sync),
 		zapLevel,
-	), zap.AddCallerSkip(1), zap.Fields(zap.String("version", Version)))
+	), zap.AddCaller(), zap.AddCallerSkip(1), zap.Fields(zap.String("version", Version)))
 	zap.ReplaceGlobals(logger)
 	return syncLogger{SyncImplementation: func() { _ = logger.Sync() }}, nil
 }
 
-func ConfigureProductionLogger(level string) (Logger, error) {
+func ConfigureProductionLogger(level string, syncs ...io.Writer) (Logger, error) {
 	zapLevel, err := zapcore.ParseLevel(level)
 	if err != nil {
 		zap.L().Fatal("failed to parse log level")
 	}
 
+	var sync io.Writer = os.Stdout
+	if len(syncs) > 0 {
+		sync = syncs[0]
+	}
+
 	logger := zap.New(zapcore.NewCore(
 		zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
-		zapcore.AddSync(os.Stdout),
+		zapcore.AddSync(sync),
 		zapLevel,
-	), zap.AddCallerSkip(1), zap.Fields(zap.String("version", Version)))
+	), zap.AddCaller(), zap.AddCallerSkip(1), zap.Fields(zap.String("version", Version)))
 	zap.ReplaceGlobals(logger)
 	return syncLogger{SyncImplementation: func() { _ = logger.Sync() }}, nil
 }
 
-func Debug(msg string, fields ...zapcore.Field) {
-	zap.L().Debug(msg, fields...)
-}
-
-func Info(msg string, fields ...zapcore.Field) {
-	zap.L().Info(msg, fields...)
-}
-
-func Warn(msg string, fields ...zapcore.Field) {
-	zap.L().Warn(msg, fields...)
-}
-
-func Error(msg string, fields ...zapcore.Field) {
-	zap.L().Error(msg, fields...)
-}
-
-func Fatal(msg string, fields ...zapcore.Field) {
-	zap.L().Fatal(msg, fields...)
-}
-
+// NewChild creates a new logger based on the default logger with the given default fields
 func NewChild(fields ...zapcore.Field) *zap.Logger {
 	return zap.L().With(fields...)
 }
 
-// Fields
-
-func Trace(trace []byte) zapcore.Field {
-	return zap.ByteString("trace", trace)
-}
-
-func Err(err error) zapcore.Field {
-	return zap.Error(err)
-}
-
-func Any(key string, val interface{}) zapcore.Field {
-	return zap.Any(key, val)
-}
-
-func String(key string, val string) zapcore.Field {
-	return zap.String(key, val)
-}
-
-func Int(key string, val int) zapcore.Field {
-	return zap.Int(key, val)
-}
-
-func Int64(key string, val int64) zapcore.Field {
-	return zap.Int64(key, val)
-}
-
-func Duration(key string, val time.Duration) zapcore.Field {
-	return zap.Duration(key, val)
+// AddField adds a new field to the default logger
+func AddField(fields ...zapcore.Field) {
+	zap.ReplaceGlobals(NewChild(fields...))
 }

--- a/pkg/logger/statements.go
+++ b/pkg/logger/statements.go
@@ -1,0 +1,26 @@
+package logger
+
+import (
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+func Debug(msg string, fields ...zapcore.Field) {
+	zap.L().Debug(msg, fields...)
+}
+
+func Info(msg string, fields ...zapcore.Field) {
+	zap.L().Info(msg, fields...)
+}
+
+func Warn(msg string, fields ...zapcore.Field) {
+	zap.L().Warn(msg, fields...)
+}
+
+func Error(msg string, fields ...zapcore.Field) {
+	zap.L().Error(msg, fields...)
+}
+
+func Fatal(msg string, fields ...zapcore.Field) {
+	zap.L().Fatal(msg, fields...)
+}

--- a/tests/add_field_test.go
+++ b/tests/add_field_test.go
@@ -1,0 +1,46 @@
+package tests
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/nullify-platform/logger/pkg/logger"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAddField tests that the logger.AddField function adds a new
+// field to the default logger
+func TestAddField(t *testing.T) {
+	var output bytes.Buffer
+
+	// create new production logger
+	log, err := logger.ConfigureProductionLogger("info", &output)
+	require.Nil(t, err)
+
+	// log a line without the added field
+	logger.Info("test")
+	log.Sync()
+	fmt.Println("stdout: " + output.String())
+
+	// check that the output doesnt include the added field
+	var jsonOutput map[string]interface{}
+	err = json.Unmarshal(output.Bytes(), &jsonOutput)
+	require.Nil(t, err)
+	_, ok := jsonOutput["my"]
+	require.False(t, ok, "stdout included new field when not expected")
+
+	// reset output and log again with the new default field
+	output = bytes.Buffer{}
+	logger.AddField(logger.String("my", "field"))
+	logger.Info("test")
+	log.Sync()
+	fmt.Println("stdout: " + output.String())
+
+	// check that the output now has the added field
+	err = json.Unmarshal(output.Bytes(), &jsonOutput)
+	require.Nil(t, err)
+	_, ok = jsonOutput["my"]
+	require.True(t, ok, "stdout didn't include the new field")
+}

--- a/tests/development_test.go
+++ b/tests/development_test.go
@@ -1,0 +1,29 @@
+package tests
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/nullify-platform/logger/pkg/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDevelopmentLogger(t *testing.T) {
+	var output bytes.Buffer
+
+	log, err := logger.ConfigureDevelopmentLogger("info", &output)
+	require.Nil(t, err)
+
+	logger.Info("test")
+	log.Sync()
+
+	fmt.Println("stdout: " + output.String())
+
+	assert.True(t, strings.Contains(output.String(), "INFO"), "stdout didn't include INFO")
+	assert.True(t, strings.Contains(output.String(), "test"), "stdout didn't include the 'test' log message")
+	assert.True(t, strings.Contains(output.String(), "tests/development_test.go:20"), "stdout didn't include the file path and line number")
+	assert.True(t, strings.Contains(output.String(), `{"version": "0.0.0"}`), "stdout didn't include version")
+}

--- a/tests/production_test.go
+++ b/tests/production_test.go
@@ -1,0 +1,33 @@
+package tests
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/nullify-platform/logger/pkg/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProductionLogger(t *testing.T) {
+	var output bytes.Buffer
+
+	log, err := logger.ConfigureProductionLogger("info", &output)
+	require.Nil(t, err)
+
+	logger.Info("test")
+	log.Sync()
+
+	fmt.Println("stdout: " + output.String())
+
+	var jsonOutput map[string]interface{}
+	err = json.Unmarshal(output.Bytes(), &jsonOutput)
+	require.Nil(t, err, "stdout was not valid json")
+
+	assert.Equal(t, "info", jsonOutput["level"], "stdout didn't include INFO")
+	assert.Equal(t, "test", jsonOutput["msg"], "stdout didn't include the 'test' log message")
+	assert.Equal(t, "tests/production_test.go:20", jsonOutput["caller"], "stdout didn't include the file path and line number")
+	assert.Equal(t, "0.0.0", jsonOutput["version"], "stdout didn't include version")
+}


### PR DESCRIPTION
## Description

- Add caller information to the default loggers (file and line number)
- Add a AddField function which allows users to add extra default json fields to the global logger
- Add unit tests in a tests directory

## Linked Issues

- closes https://github.com/Nullify-Platform/Logger/issues/6
- closes https://github.com/Nullify-Platform/Logger/issues/8
- closes https://github.com/Nullify-Platform/Logger/issues/16

## Checklist

- [x] I have added one of the `patch`, `minor`, `major` or `no-release` labels
- [x] I have linked an issue from this repository using the **Development** option
- [x] I have performed a self-review of my own code
- [x] I have checked for redundant or commented out code
- [x] I have commented my code where I can't make it self-documenting
- [x] I have made corresponding changes to the documentation
- [x] I have added any appropriate tests
