### PR TITLE
auto-releases and renovate grouping

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -1,16 +1,15 @@
-name: Golang CI
+name: CI Go
 on:
   push:
     branches:
       - main
   pull_request:
     paths:
-      - cmd/**/*.go
-      - internal/**/*.go
-      - pkg/**/*.go
+      - .github/workflows/go.yml
+      - '**.go'
       - go.*
       - Makefile
-      - .github/workflows/go.yml
+run-name: CI Go ${{ github.sha }} by @${{ github.actor }}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -33,16 +32,20 @@ jobs:
       - uses: actions/checkout@v3
       - name: Lint
         run: golangci-lint run ./...
-  code-coverage:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Unit Tests
         env:
-          CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |
-          go install github.com/boumenot/gocover-cobertura@latest
+          go install github.com/boumenot/gocover-cobertura@v1.2.0
           make cov
-          curl -Os https://uploader.codecov.io/latest/linux/codecov
-          chmod +x codecov
-          ./codecov -t ${CODECOV_TOKEN} 
+          curl -Os https://uploader.codecov.io/v0.3.5/linux/codecov
+          if sha256sum codecov | grep -q "080b43eaec3434326bb0f61653a82d27aba15c311ddde9d3f68cb364314f7aae"; then
+            chmod +x codecov
+            ./codecov -t ${CODECOV_TOKEN} 
+          else
+            echo "sha256 of codecov changed"
+          fi

--- a/.github/workflows/ci-require-labels.yml
+++ b/.github/workflows/ci-require-labels.yml
@@ -1,0 +1,19 @@
+# Require labels to be added to a PR before merging
+# This is configured as a branch protection setting
+name: CI Require Labels
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+  merge_group:
+run-name: CI Require Labels ${{ github.sha }} by @${{ github.actor }}
+jobs:
+  require-labels:
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    outputs:
+      status: ${{ steps.require-labels.outputs.status }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Require Labels
+        id: require-labels
+        uses: nullify-platform/github-actions/actions/require-labels@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: Create Release
+on:
+  workflow_dispatch:
+    inputs:
+      releaseType:
+        description: Create a draft release
+        required: true
+        type: boolean
+        default: true
+  push:
+    branches:
+      - main
+concurrency:
+  group: release
+  cancel-in-progress: false
+run-name: Release ${{ github.sha }} by @${{ github.actor }}
+permissions:
+  contents: write
+  id-token: write
+  pull-requests: read
+jobs:
+  get-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get-version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Get Release Version
+        id: get-version
+        uses: nullify-platform/github-actions/actions/release-version@main
+      - run: |
+          echo "config-file-parser @ ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
+          echo "VERSION:   ${{ steps.get-version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "SHORT_SHA: $(git rev-parse --short HEAD)" >> $GITHUB_STEP_SUMMARY
+  release:
+    if: ${{ needs.get-version.outputs.version != 'undefined' || (github.event_name == 'workflow_dispatch' && needs.get-version.outputs.version != 'undefined') }}
+    runs-on: ubuntu-latest
+    needs: [ get-version ]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Generate Release Tag
+        run: echo "RELEASE_TAG=v${{ needs.get-version.outputs.version }}" >> $GITHUB_ENV
+      - name: Generate Release
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: false
+          generate_release_notes: true
+          append_body: true
+          tag_name: ${{ env.RELEASE_TAG }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,6 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
-github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=

--- a/renovate.json
+++ b/renovate.json
@@ -4,24 +4,19 @@
     "config:base"
   ],
   "timezone": "Australia/Sydney",
-  "schedule": [
-    "before 9am on monday"
-  ],
+  "schedule": ["before 9am on monday"],
+  "docker": {
+    "pinDigests": true
+  },
+  "labels": ["patch"],
+  "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"],
+  "separateMajorMinor": false,
   "packageRules": [
     {
-      "groupName": "AWS Go SDK",
-      "groupSlug": "aws-go",
-      "matchPackagePrefixes": ["github.com/aws/aws-sdk-go-v2"],
-      "matchUpdateTypes": ["patch", "pin", "digest"],
-      "automerge": true
-    },
-    {
-      "groupName": "AWS Python SDK",
-      "groupSlug": "aws-python",
-      "matchPackagePrefixes": ["boto"],
-      "matchUpdateTypes": ["patch", "pin", "digest"],
-      "automerge": true
+      "groupName": "Package Updates",
+      "groupSlug": "package-updates",
+      "matchUpdateTypes": ["major", "minor", "patch"],
+      "matchPackagePatterns": ["*"]
     }
-  ],
-  "platformAutomerge": true
+  ]
 }


### PR DESCRIPTION
## Description

Auto-release on merges to main.
Grouping of all packages in renovate updates.

## Linked Issues

- resolves https://github.com/Nullify-Platform/Logger/issues/19

[GitHub Issue Linking Docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)

## Checklist

- [x] I have added one of the `patch`, `minor`, `major` or `no-release` labels
- [x] I have linked an issue from this repository using the **Development** option
- [x] I have performed a self-review of my own code
- [x] I have checked for redundant or commented out code
- [x] I have commented my code where I can't make it self-documenting
- [x] I have made corresponding changes to the documentation
- [x] I have added any appropriate tests
