### PR TITLE
add support for creating a new logger with options

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -6,6 +6,8 @@ import (
 
 type Logger interface {
 	NewChild(fields ...Field) Logger
+	WithOptions(opts ...Option) Logger
+
 	AddField(fields ...Field)
 	Sync()
 
@@ -26,6 +28,12 @@ type logger struct {
 // NewChild creates a new logger based on the default logger with the given default fields
 func (l *logger) NewChild(fields ...Field) Logger {
 	newLogger := l.underlyingLogger.With(fields...)
+	return &logger{underlyingLogger: newLogger}
+}
+
+// WithOptions adds a new field to the default logger
+func (l *logger) WithOptions(opts ...Option) Logger {
+	newLogger := l.underlyingLogger.WithOptions(opts...)
 	return &logger{underlyingLogger: newLogger}
 }
 

--- a/pkg/logger/options.go
+++ b/pkg/logger/options.go
@@ -1,0 +1,13 @@
+package logger
+
+import (
+	"go.uber.org/zap"
+)
+
+type Option = zap.Option
+
+// Options
+
+func AddCallerSkip(n int) zap.Option {
+	return zap.AddCallerSkip(n)
+}

--- a/tests/with_options_test.go
+++ b/tests/with_options_test.go
@@ -1,0 +1,22 @@
+package tests
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/nullify-platform/logger/pkg/logger"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// TestAddField tests that the logger.AddField function adds a new
+// field to the default logger
+func TestWithOptions(t *testing.T) {
+	var output bytes.Buffer
+
+	// create new production logger
+	myLogger, err := logger.ConfigureProductionLogger("info", &output)
+	require.Nil(t, err)
+
+	myLogger.NewChild().WithOptions(zap.AddCallerSkip(5))
+}


### PR DESCRIPTION
## Description

We need the ability to add options to the logger so that injecting custom logger implementations into libraries (e.g. HTTP std lib) can be done while maintaining correct source code line numbers in log statements.

[GitHub Issue Linking Docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)

## Checklist

- [ ] I have added one of the `patch`, `minor`, `major` or `no-release` labels
- [ ] I have linked an issue from this repository using the **Development** option
- [ ] I have performed a self-review of my own code
- [ ] I have checked for redundant or commented out code
- [ ] I have commented my code where I can't make it self-documenting
- [ ] I have made corresponding changes to the documentation
- [ ] I have added any appropriate tests
