### PR TITLE
update to go1.20 and update ci to use github actions instead of containers

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -1,24 +1,19 @@
 name: CI Go
 on:
-  push:
-    branches:
-      - main
   pull_request:
-    paths:
-      - .github/workflows/go.yml
-      - '**.go'
-      - go.*
-      - Makefile
 run-name: CI Go ${{ github.sha }} by @${{ github.actor }}
 jobs:
-  build:
+  lint-build-tidy-test:
     runs-on: ubuntu-latest
-    container: golang:1.22.0
     steps:
-      - name: setup
-        run: |
-          git config --global --add safe.directory $(pwd)
       - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: lint
+        uses: golangci/golangci-lint-action@v4
+        with:
+          version: v1.56.2
       - name: build
         run: make build
       - name: tidy
@@ -27,10 +22,3 @@ jobs:
           git diff --exit-code
       - name: test
         run: make unit
-  lint:
-    runs-on: ubuntu-latest
-    container: golangci/golangci-lint:v1.56.2
-    steps:
-      - uses: actions/checkout@v4
-      - name: Lint
-        run: golangci-lint run ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,23 +1,23 @@
 run:
   timeout: 5m
+  modules-download-mode: readonly
 linters:
-  disable-all: true
   enable:
-    # default
+    # defaults
     - errcheck
     - gosimple
     - govet
     - ineffassign
     - staticcheck
-    - typecheck
     - unused
-    # style
+    # extra
     - gofmt
+    - goimports
+    - revive
     - stylecheck
+    - tagalign
     - whitespace
-    # security
-    - gosec
-linters-settings:
-  gosec:
-    excludes:
-      - G107
+issues:
+  exclude-use-default: false
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,3 +1,4 @@
+// Package main is an example application that uses the logger package
 package main
 
 import "github.com/nullify-platform/logger/pkg/logger"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nullify-platform/logger
 
-go 1.19
+go 1.20
 
 require go.uber.org/multierr v1.10.0 // indirect
 

--- a/pkg/logger/configure.go
+++ b/pkg/logger/configure.go
@@ -11,8 +11,9 @@ import (
 // Version is the current version of the application
 // override this value with ldflags
 // e.g. -ldflags "-X 'github.com/nullify-platform/logger/pkg/logger.Version=$(VERSION)'"
-var Version string = "0.0.0"
+var Version = "0.0.0"
 
+// ConfigureDevelopmentLogger configures a development logger which is more human readable instead of JSON
 func ConfigureDevelopmentLogger(level string, syncs ...io.Writer) (Logger, error) {
 	// configure level
 	zapLevel, err := zapcore.ParseLevel(level)
@@ -39,6 +40,7 @@ func ConfigureDevelopmentLogger(level string, syncs ...io.Writer) (Logger, error
 	return &logger{underlyingLogger: zapLogger}, nil
 }
 
+// ConfigureProductionLogger configures a JSON production logger
 func ConfigureProductionLogger(level string, syncs ...io.Writer) (Logger, error) {
 	zapLevel, err := zapcore.ParseLevel(level)
 	if err != nil {

--- a/pkg/logger/fields.go
+++ b/pkg/logger/fields.go
@@ -7,62 +7,87 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
+// Field an enum type for log message fields
 type Field = zapcore.Field
 
 // Fields
 
+// Trace adds a stac trace field to the logger
 func Trace(trace []byte) Field {
 	return zap.ByteString("trace", trace)
 }
 
+// Any adds a field to the logger
 func Any(key string, val interface{}) Field {
 	return zap.Any(key, val)
 }
 
+// Err adds an error field to the logger
 func Err(err error) Field {
 	return zap.Error(err)
 }
 
+// Errs adds a ;ist of errors field to the logger
 func Errs(msg string, errs []error) Field {
 	return zap.Errors(msg, errs)
 }
 
+// String adds a string field to the logger
 func String(key string, val string) Field {
 	return zap.String(key, val)
 }
 
+// Strings adds a list of strings field to the logger
 func Strings(key string, val []string) Field {
 	return zap.Strings(key, val)
 }
 
+// Bool adds a bool field to the logger
 func Bool(key string, val bool) Field {
 	return zap.Bool(key, val)
 }
 
+// Bools adds a list of bools field to the logger
 func Bools(key string, val []bool) Field {
 	return zap.Bools(key, val)
 }
 
+// Int adds an int field to the logger
 func Int(key string, val int) Field {
 	return zap.Int(key, val)
 }
 
+// Ints adds a list of ints field to the logger
 func Ints(key string, val []int) Field {
 	return zap.Ints(key, val)
 }
 
+// Int32 adds an int32 field to the logger
+func Int32(key string, val int32) Field {
+	return zap.Int32(key, val)
+}
+
+// Int32s adds a list of int32s field to the logger
+func Int32s(key string, val []int32) Field {
+	return zap.Int32s(key, val)
+}
+
+// Int64 adds an int64 field to the logger
 func Int64(key string, val int64) Field {
 	return zap.Int64(key, val)
 }
 
+// Int64s adds a list of int64s field to the logger
 func Int64s(key string, val []int64) Field {
 	return zap.Int64s(key, val)
 }
 
+// Duration adds a time duration field to the logger
 func Duration(key string, val time.Duration) Field {
 	return zap.Duration(key, val)
 }
 
+// Durations adds a list of time durations field to the logger
 func Durations(key string, val []time.Duration) Field {
 	return zap.Durations(key, val)
 }

--- a/pkg/logger/globals.go
+++ b/pkg/logger/globals.go
@@ -16,22 +16,27 @@ func AddField(fields ...Field) {
 
 // levels
 
+// Debug logs a message with the debug level
 func Debug(msg string, fields ...Field) {
 	zap.L().Debug(msg, fields...)
 }
 
+// Info logs a message with the info level
 func Info(msg string, fields ...Field) {
 	zap.L().Info(msg, fields...)
 }
 
+// Warn logs a message with the warn level
 func Warn(msg string, fields ...Field) {
 	zap.L().Warn(msg, fields...)
 }
 
+// Error logs a message with the error level
 func Error(msg string, fields ...Field) {
 	zap.L().Error(msg, fields...)
 }
 
+// Fatal logs a message with the fatal level and then calls os.Exit(1)
 func Fatal(msg string, fields ...Field) {
 	zap.L().Fatal(msg, fields...)
 }

--- a/pkg/logger/http.go
+++ b/pkg/logger/http.go
@@ -7,6 +7,8 @@ import (
 	"go.uber.org/zap"
 )
 
+// NewLoggingTransport creates a new http.RoundTripper that logs requests and responses
+// with the global logge
 func NewLoggingTransport(baseTransport http.RoundTripper, service string) http.RoundTripper {
 	return &LoggingTransport{
 		baseTransport: baseTransport,
@@ -14,6 +16,8 @@ func NewLoggingTransport(baseTransport http.RoundTripper, service string) http.R
 	}
 }
 
+// NewLoggingTransportWithLogger creates a new http.RoundTripper that logs requests and responses
+// with a custom logger
 func NewLoggingTransportWithLogger(baseTransport http.RoundTripper, logger Logger, service string) http.RoundTripper {
 	return &LoggingTransport{
 		logger:        logger,
@@ -22,12 +26,14 @@ func NewLoggingTransportWithLogger(baseTransport http.RoundTripper, logger Logge
 	}
 }
 
+// LoggingTransport is an http.RoundTripper that logs HTTP requests and responses
 type LoggingTransport struct {
 	baseTransport http.RoundTripper
 	logger        Logger
 	service       string
 }
 
+// RoundTrip executes the HTTP request and logs the request and response summary
 func (t *LoggingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	start := time.Now()
 
@@ -69,6 +75,7 @@ func (t *LoggingTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 	return res, err
 }
 
+// HTTPRequestSummary is a JSON struct definition for the summary of an HTTP request
 type HTTPRequestSummary struct {
 	Service         string        `json:"service"`
 	Host            string        `json:"host"`
@@ -106,6 +113,7 @@ func (l *logger) HTTPRequest(service string, duration time.Duration, req *http.R
 			StatusCode:      res.StatusCode,
 			RequestHeaders:  reqHeaders,
 			ResponseHeaders: resHeaders,
+			Duration:        duration,
 		}),
 	)
 }

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,9 +1,12 @@
+// Package logger implements a logger interface with an implementation using the zap logger
 package logger
 
 import (
 	"go.uber.org/zap"
 )
 
+// Logger is the interface that for all the basic logging methods
+// this package also provides a global implementation of the methods in this interface
 type Logger interface {
 	NewChild(fields ...Field) Logger
 	WithOptions(opts ...Option) Logger
@@ -42,26 +45,32 @@ func (l *logger) AddFields(fields ...Field) {
 	l.underlyingLogger = l.underlyingLogger.With(fields...)
 }
 
+// Sync flushes any buffered log entries
 func (l *logger) Sync() {
 	_ = l.underlyingLogger.Sync()
 }
 
+// Debug logs a message with the debug level
 func (l *logger) Debug(msg string, fields ...Field) {
 	l.underlyingLogger.Debug(msg, fields...)
 }
 
+// Info logs a message with the info level
 func (l *logger) Info(msg string, fields ...Field) {
 	l.underlyingLogger.Info(msg, fields...)
 }
 
+// Warn logs a message with the warn level
 func (l *logger) Warn(msg string, fields ...Field) {
 	l.underlyingLogger.Warn(msg, fields...)
 }
 
+// Error logs a message with the error level
 func (l *logger) Error(msg string, fields ...Field) {
 	l.underlyingLogger.Error(msg, fields...)
 }
 
+// Fatal logs a message with the fatal level and then calls os.Exit(1)
 func (l *logger) Fatal(msg string, fields ...Field) {
 	l.underlyingLogger.Fatal(msg, fields...)
 }

--- a/pkg/logger/options.go
+++ b/pkg/logger/options.go
@@ -4,10 +4,12 @@ import (
 	"go.uber.org/zap"
 )
 
+// Option an enum type for logger options
 type Option = zap.Option
 
 // Options
 
-func AddCallerSkip(n int) zap.Option {
+// AddCallerSkip adds n to the number of callers skipped by the logger
+func AddCallerSkip(n int) Option {
 	return zap.AddCallerSkip(n)
 }

--- a/renovate.json
+++ b/renovate.json
@@ -18,5 +18,13 @@
       "matchUpdateTypes": ["major", "minor", "patch"],
       "matchPackagePatterns": ["*"]
     }
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": ["^\\.github/workflows/ci-go\\.yml$"],
+      "matchStrings": ["version: (?<currentValue>.*?)"],
+      "depNameTemplate": "github.com/golangci/golangci-lint",
+      "datasourceTemplate": "go"
+    }
   ]
 }

--- a/tests/with_options_test.go
+++ b/tests/with_options_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/nullify-platform/logger/pkg/logger"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 )
 
 // TestAddField tests that the logger.AddField function adds a new
@@ -18,5 +17,5 @@ func TestWithOptions(t *testing.T) {
 	myLogger, err := logger.ConfigureProductionLogger("info", &output)
 	require.Nil(t, err)
 
-	myLogger.NewChild().WithOptions(zap.AddCallerSkip(5))
+	myLogger.NewChild().WithOptions(logger.AddCallerSkip(5))
 }


### PR DESCRIPTION
## Description

- update ci to use github actions instead of containers
- add some more linters
- fix the linting errors
- update the go version to 1.20

## Checklist

- [ ] I have added one of the `patch`, `minor`, `major` or `no-release` labels
- [ ] I have linked an issue from this repository using the **Development** option
- [ ] I have performed a self-review of my own code
- [ ] I have checked for redundant or commented out code
- [ ] I have commented my code where I can't make it self-documenting
- [ ] I have made corresponding changes to the documentation
- [ ] I have added any appropriate tests
