### PR TITLE
fix(deps): update module path

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,8 +5,8 @@ import (
 	"context"
 	"errors"
 
-	"github.com/nullify-platform/logger/pkg/logger"
-	"github.com/nullify-platform/logger/pkg/logger/tracer"
+	"github.com/nullify-platform/logger/v2/pkg/logger"
+	"github.com/nullify-platform/logger/v2/pkg/logger/tracer"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/nullify-platform/logger
+module github.com/nullify-platform/logger/v2
 
 go 1.21.6
 

--- a/pkg/logger/configure.go
+++ b/pkg/logger/configure.go
@@ -6,7 +6,7 @@ import (
 	"os"
 
 	"github.com/getsentry/sentry-go"
-	"github.com/nullify-platform/logger/pkg/logger/tracer"
+	"github.com/nullify-platform/logger/v2/pkg/logger/tracer"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"

--- a/pkg/logger/http.go
+++ b/pkg/logger/http.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/nullify-platform/logger/pkg/logger/tracer"
+	"github.com/nullify-platform/logger/v2/pkg/logger/tracer"
 	"go.uber.org/zap"
 )
 

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/getsentry/sentry-go"
-	"github.com/nullify-platform/logger/pkg/logger/tracer"
+	"github.com/nullify-platform/logger/v2/pkg/logger/tracer"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"

--- a/pkg/logger/middleware/logger.go
+++ b/pkg/logger/middleware/logger.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	"github.com/getsentry/sentry-go"
-	"github.com/nullify-platform/logger/pkg/logger"
-	"github.com/nullify-platform/logger/pkg/logger/tracer"
+	"github.com/nullify-platform/logger/v2/pkg/logger"
+	"github.com/nullify-platform/logger/v2/pkg/logger/tracer"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )

--- a/tests/add_field_test.go
+++ b/tests/add_field_test.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/nullify-platform/logger/pkg/logger"
+	"github.com/nullify-platform/logger/v2/pkg/logger"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/development_test.go
+++ b/tests/development_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/nullify-platform/logger/pkg/logger"
+	"github.com/nullify-platform/logger/v2/pkg/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/tests/production_test.go
+++ b/tests/production_test.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/nullify-platform/logger/pkg/logger"
+	"github.com/nullify-platform/logger/v2/pkg/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/tests/with_options_test.go
+++ b/tests/with_options_test.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/nullify-platform/logger/pkg/logger"
+	"github.com/nullify-platform/logger/v2/pkg/logger"
 	"github.com/stretchr/testify/require"
 )
 


### PR DESCRIPTION
Turns out go requires you to update the module path when you make a major version change 💀

## Description

Updates the `.mod` file so that other modules can actually import it.
