### PR TITLE
chore: rename function to `F()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,48 +10,48 @@ To make the most use of this library, you have to ensure that your service passe
 One big change is that the logger is no longer a global variable. It is now linked to the context, so you need to ensure that you pass the context.
 
 ```go
-logger.FromContext(ctx).Info("this is a log message")
+logger.F(ctx).Info("this is a log message")
 ```
 
 First, declare the background context in your main function, and then inject the logger into the context.
 
 ```go
 func main() {
-		ctx := context.Background()
-		ctx, err := logger.ConfigureProductionLogger(ctx, "info") // inject logger into context
+  ctx := context.Background()
+  ctx, err := logger.ConfigureProductionLogger(ctx, "info") // inject logger into context
 
-		// There is no longer a global logger. It is always linked to the context, to ensure that log messages have the appropriate span and trace IDs linked to them.
-		defer logger.FromContext(ctx).Sync() // defer the sync of the logger to ensure all logs are written
+  // There is no longer a global logger. It is always linked to the context, to ensure that log messages have the appropriate span and trace IDs linked to them.
+  defer logger.F(ctx).Sync() // defer the sync of the logger to ensure all logs are written
 
-		// Initiate a new span, and defer ending the span to record the end of this piece of work.
-		ctx, span := tracer.FromContext(ctx).Start(ctx, "main")
-		defer span.End()
+  // Initiate a new span, and defer ending the span to record the end of this piece of work.
+  ctx, span := tracer.F(ctx).Start(ctx, "main")
+  defer span.End()
 
 
-		// You can add more contextual event information to spans through the span.AddEvent method. This is analogous to adding a log message, and has an associated timestamp that is recorded.
-		span.AddEvent("a piece of work is starting within the span")
+  // You can add more contextual event information to spans through the span.AddEvent method. This is analogous to adding a log message, and has an associated timestamp that is recorded.
+  span.AddEvent("a piece of work is starting within the span")
 
-		// You can also set attributes to the span to provide more context to the span, typically as key-value pairs.
-		span.SetAttributes(
-				attribute.String("customer-id", "018e4fc1-c079-70ce-84a0-9591295d96aa"),
-				attribute.Int64("request-count", 80),
-		)
+  // You can also set attributes to the span to provide more context to the span, typically as key-value pairs.
+  span.SetAttributes(
+    attribute.String("customer-id", "018e4fc1-c079-70ce-84a0-9591295d96aa"),
+    attribute.Int64("request-count", 80),
+  )
 
-		// You need to ensure that you pass context to other functions so that the logger and tracer are available to them.
-		anotherFunction(ctx)
+  // You need to ensure that you pass context to other functions so that the logger and tracer are available to them.
+  anotherFunction(ctx)
 }
 
 func anotherFunction(ctx context.Context) {
-		// Retrieve the tracer from the context
-		ctx, span := tracer.FromContext(ctx).Start(ctx, "some-other-work")
-		defer span.End()
+  // Retrieve the tracer from the context
+  ctx, span := tracer.F(ctx).Start(ctx, "some-other-work")
+  defer span.End()
 
-		// This will automatically set the parent function span to be the parent span of this new span that has started, within this trace.
+  // This will automatically set the parent function span to be the parent span of this new span that has started, within this trace.
 
-		// To record errors, you can use the logger.FromContext(ctx).Error() call. This will automatically capture any errors that you pass into it and pass them to GlitchTip. It will also set the span to errored, so it is highlighted in Grafana.
+  // To record errors, you can use the logger.Fctx).Error() call. This will automatically capture any errors that you pass into it and pass them to GlitchTip. It will also set the span to errored, so it is highlighted in Grafana.
 
-		error := errors.New("this is an error")
-		logger.FromContext(err).Error("this is an error", error)
+  error := errors.New("this is an error")
+  logger.F(err).Error("this is an error", error)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To make the most use of this library, you have to ensure that your service passe
 One big change is that the logger is no longer a global variable. It is now linked to the context, so you need to ensure that you pass the context.
 
 ```go
-logger.F(ctx).Info("this is a log message")
+logger.L(ctx).Info("this is a log message")
 ```
 
 First, declare the background context in your main function, and then inject the logger into the context.
@@ -21,10 +21,10 @@ func main() {
   ctx, err := logger.ConfigureProductionLogger(ctx, "info") // inject logger into context
 
   // There is no longer a global logger. It is always linked to the context, to ensure that log messages have the appropriate span and trace IDs linked to them.
-  defer logger.F(ctx).Sync() // defer the sync of the logger to ensure all logs are written
+  defer logger.L(ctx).Sync() // defer the sync of the logger to ensure all logs are written
 
   // Initiate a new span, and defer ending the span to record the end of this piece of work.
-  ctx, span := tracer.F(ctx).Start(ctx, "main")
+  ctx, span := tracer.FromContext(ctx).Start(ctx, "main")
   defer span.End()
 
 
@@ -43,15 +43,15 @@ func main() {
 
 func anotherFunction(ctx context.Context) {
   // Retrieve the tracer from the context
-  ctx, span := tracer.F(ctx).Start(ctx, "some-other-work")
+  ctx, span := tracer.FromContext(ctx).Start(ctx, "some-other-work")
   defer span.End()
 
   // This will automatically set the parent function span to be the parent span of this new span that has started, within this trace.
 
-  // To record errors, you can use the logger.F(ctx).Error() call. This will automatically capture any errors that you pass into it and pass them to GlitchTip. It will also set the span to errored, so it is highlighted in Grafana.
+  // To record errors, you can use the logger.L(ctx).Error() call. This will automatically capture any errors that you pass into it and pass them to GlitchTip. It will also set the span to errored, so it is highlighted in Grafana.
 
   error := errors.New("this is an error")
-  logger.F(err).Error("this is an error", error)
+  logger.L(err).Error("this is an error", error)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ func anotherFunction(ctx context.Context) {
 
   // This will automatically set the parent function span to be the parent span of this new span that has started, within this trace.
 
-  // To record errors, you can use the logger.Fctx).Error() call. This will automatically capture any errors that you pass into it and pass them to GlitchTip. It will also set the span to errored, so it is highlighted in Grafana.
+  // To record errors, you can use the logger.F(ctx).Error() call. This will automatically capture any errors that you pass into it and pass them to GlitchTip. It will also set the span to errored, so it is highlighted in Grafana.
 
   error := errors.New("this is an error")
   logger.F(err).Error("this is an error", error)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -13,7 +13,7 @@ func main() {
 	ctx := context.Background()
 	ctx, err := logger.ConfigureProductionLogger(ctx, "info")
 	defer logger.F(ctx).Sync()
-	ctx, span := tracer.FromContext(ctx).Start(ctx, "main")
+	ctx, span := tracer.F(ctx).Start(ctx, "main")
 	defer span.End()
 
 	span.AddEvent("main function started")
@@ -27,7 +27,7 @@ func main() {
 }
 
 func anotherFunctionRenamed(ctx context.Context) {
-	ctx, span := tracer.FromContext(ctx).Start(ctx, "extended feature")
+	ctx, span := tracer.F(ctx).Start(ctx, "extended feature")
 	defer span.End()
 
 	logger.F(ctx).Info("another function started")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -12,14 +12,14 @@ import (
 func main() {
 	ctx := context.Background()
 	ctx, err := logger.ConfigureProductionLogger(ctx, "info")
-	defer logger.FromContext(ctx).Sync()
+	defer logger.F(ctx).Sync()
 	ctx, span := tracer.FromContext(ctx).Start(ctx, "main")
 	defer span.End()
 
 	span.AddEvent("main function started")
 
 	if err != nil {
-		logger.FromContext(ctx).Error("error configuring logger", logger.Err(err))
+		logger.F(ctx).Error("error configuring logger", logger.Err(err))
 		panic(err)
 	}
 
@@ -30,6 +30,6 @@ func anotherFunctionRenamed(ctx context.Context) {
 	ctx, span := tracer.FromContext(ctx).Start(ctx, "extended feature")
 	defer span.End()
 
-	logger.FromContext(ctx).Info("another function started")
-	logger.FromContext(ctx).Error("something terbl happened", logger.Err(errors.New("test error 2 in dev")))
+	logger.F(ctx).Info("another function started")
+	logger.F(ctx).Error("something terbl happened", logger.Err(errors.New("test error 2 in dev")))
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -12,14 +12,14 @@ import (
 func main() {
 	ctx := context.Background()
 	ctx, err := logger.ConfigureProductionLogger(ctx, "info")
-	defer logger.F(ctx).Sync()
-	ctx, span := tracer.F(ctx).Start(ctx, "main")
+	defer logger.L(ctx).Sync()
+	ctx, span := tracer.FromContext(ctx).Start(ctx, "main")
 	defer span.End()
 
 	span.AddEvent("main function started")
 
 	if err != nil {
-		logger.F(ctx).Error("error configuring logger", logger.Err(err))
+		logger.L(ctx).Error("error configuring logger", logger.Err(err))
 		panic(err)
 	}
 
@@ -27,9 +27,9 @@ func main() {
 }
 
 func anotherFunctionRenamed(ctx context.Context) {
-	ctx, span := tracer.F(ctx).Start(ctx, "extended feature")
+	ctx, span := tracer.FromContext(ctx).Start(ctx, "extended feature")
 	defer span.End()
 
-	logger.F(ctx).Info("another function started")
-	logger.F(ctx).Error("something terbl happened", logger.Err(errors.New("test error 2 in dev")))
+	logger.L(ctx).Info("another function started")
+	logger.L(ctx).Error("something terbl happened", logger.Err(errors.New("test error 2 in dev")))
 }

--- a/pkg/logger/globals.go
+++ b/pkg/logger/globals.go
@@ -7,8 +7,8 @@ import (
 	"go.uber.org/zap"
 )
 
-// FromContext returns the logger from the context
-func FromContext(ctx context.Context) Logger {
+// F returns the logger from the context
+func F(ctx context.Context) Logger {
 	if ctx == nil {
 		return nil
 	}

--- a/pkg/logger/globals.go
+++ b/pkg/logger/globals.go
@@ -7,8 +7,8 @@ import (
 	"go.uber.org/zap"
 )
 
-// F returns the logger from the context
-func F(ctx context.Context) Logger {
+// L returns the logger from the context
+func L(ctx context.Context) Logger {
 	if ctx == nil {
 		return nil
 	}

--- a/pkg/logger/http.go
+++ b/pkg/logger/http.go
@@ -29,8 +29,8 @@ type LoggingTransport struct {
 
 // RoundTrip executes the HTTP request and logs the request and response summary
 func (t *LoggingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	ctx, span := tracer.F(t.ctx).Start(t.ctx, req.URL.EscapedPath())
-	defer F(ctx).Sync()
+	ctx, span := tracer.FromContext(t.ctx).Start(t.ctx, req.URL.EscapedPath())
+	defer L(ctx).Sync()
 	defer span.End()
 
 	start := time.Now()
@@ -65,7 +65,7 @@ func (t *LoggingTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 	})
 
 	if t.logger == nil {
-		F(ctx).Info("request summary", summary)
+		L(ctx).Info("request summary", summary)
 	} else {
 		t.logger.Info("request summary", summary)
 	}

--- a/pkg/logger/http.go
+++ b/pkg/logger/http.go
@@ -30,7 +30,7 @@ type LoggingTransport struct {
 // RoundTrip executes the HTTP request and logs the request and response summary
 func (t *LoggingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	ctx, span := tracer.FromContext(t.ctx).Start(t.ctx, req.URL.EscapedPath())
-	defer FromContext(ctx).Sync()
+	defer F(ctx).Sync()
 	defer span.End()
 
 	start := time.Now()
@@ -65,7 +65,7 @@ func (t *LoggingTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 	})
 
 	if t.logger == nil {
-		FromContext(ctx).Info("request summary", summary)
+		F(ctx).Info("request summary", summary)
 	} else {
 		t.logger.Info("request summary", summary)
 	}

--- a/pkg/logger/http.go
+++ b/pkg/logger/http.go
@@ -29,7 +29,7 @@ type LoggingTransport struct {
 
 // RoundTrip executes the HTTP request and logs the request and response summary
 func (t *LoggingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	ctx, span := tracer.FromContext(t.ctx).Start(t.ctx, req.URL.EscapedPath())
+	ctx, span := tracer.F(t.ctx).Start(t.ctx, req.URL.EscapedPath())
 	defer F(ctx).Sync()
 	defer span.End()
 

--- a/pkg/logger/middleware/logger.go
+++ b/pkg/logger/middleware/logger.go
@@ -52,7 +52,7 @@ func LoggingMiddleware(next http.Handler) http.Handler {
 		defer func() {
 			// Check if there is a parent span
 			if parentSpan := trace.SpanFromContext(ctx); !parentSpan.SpanContext().IsValid() {
-				logger.FromContext(ctx).Sync()
+				logger.F(ctx).Sync()
 			}
 		}()
 		defer span.End()
@@ -64,7 +64,7 @@ func LoggingMiddleware(next http.Handler) http.Handler {
 				}
 
 				w.WriteHeader(http.StatusInternalServerError)
-				logger.FromContext(ctx).Error(
+				logger.F(ctx).Error(
 					"endpoint handler panicked",
 					logger.Any("err", err),
 					logger.Trace(debug.Stack()),
@@ -101,7 +101,7 @@ func LoggingMiddleware(next http.Handler) http.Handler {
 		)
 
 		if r.URL.EscapedPath() != "/healthcheck" {
-			logger.FromContext(ctx).Info(
+			logger.F(ctx).Info(
 				"new request",
 				logger.Any("requestSummary", metadata),
 			)
@@ -126,7 +126,7 @@ func LoggingMiddleware(next http.Handler) http.Handler {
 		span.AddEvent("response parsing complete")
 
 		if r.URL.EscapedPath() != "/healthcheck" {
-			logger.FromContext(ctx).Info(
+			logger.F(ctx).Info(
 				"request summary",
 				logger.Any("requestSummary", metadata),
 			)

--- a/pkg/logger/middleware/logger.go
+++ b/pkg/logger/middleware/logger.go
@@ -48,7 +48,7 @@ type httpRequestMetadata struct {
 // LoggingMiddleware logs the incoming request and the outgoing response and adds relevant tracing information
 func LoggingMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx, span := tracer.FromContext(r.Context()).Start(r.Context(), fmt.Sprint("http call", r.URL.EscapedPath()))
+		ctx, span := tracer.F(r.Context()).Start(r.Context(), fmt.Sprint("http call", r.URL.EscapedPath()))
 		defer func() {
 			// Check if there is a parent span
 			if parentSpan := trace.SpanFromContext(ctx); !parentSpan.SpanContext().IsValid() {

--- a/pkg/logger/tracer/tracer.go
+++ b/pkg/logger/tracer/tracer.go
@@ -11,8 +11,8 @@ import (
 type tracerCtxKey struct{}
 type traceProviderCtxKey struct{}
 
-// FromContext returns the tracer from the context
-func FromContext(ctx context.Context) trace.Tracer {
+// F returns the tracer from the context
+func F(ctx context.Context) trace.Tracer {
 	t, _ := ctx.Value(tracerCtxKey{}).(trace.Tracer)
 	return t
 }

--- a/pkg/logger/tracer/tracer.go
+++ b/pkg/logger/tracer/tracer.go
@@ -11,8 +11,8 @@ import (
 type tracerCtxKey struct{}
 type traceProviderCtxKey struct{}
 
-// F returns the tracer from the context
-func F(ctx context.Context) trace.Tracer {
+// FromContext returns the tracer from the context
+func FromContext(ctx context.Context) trace.Tracer {
 	t, _ := ctx.Value(tracerCtxKey{}).(trace.Tracer)
 	return t
 }

--- a/tests/add_field_test.go
+++ b/tests/add_field_test.go
@@ -20,7 +20,7 @@ func TestAddField(t *testing.T) {
 	// create new production logger
 	ctx, err := logger.ConfigureProductionLogger(ctx, "info", &output)
 	require.Nil(t, err)
-	myLogger := logger.F(ctx)
+	myLogger := logger.L(ctx)
 
 	// log a line without the added field
 	myLogger.Info("test")

--- a/tests/add_field_test.go
+++ b/tests/add_field_test.go
@@ -20,7 +20,7 @@ func TestAddField(t *testing.T) {
 	// create new production logger
 	ctx, err := logger.ConfigureProductionLogger(ctx, "info", &output)
 	require.Nil(t, err)
-	myLogger := logger.FromContext(ctx)
+	myLogger := logger.F(ctx)
 
 	// log a line without the added field
 	myLogger.Info("test")

--- a/tests/development_test.go
+++ b/tests/development_test.go
@@ -18,7 +18,7 @@ func TestDevelopmentLogger(t *testing.T) {
 
 	ctx, err := logger.ConfigureDevelopmentLogger(ctx, "info", &output)
 	require.Nil(t, err)
-	log := logger.FromContext(ctx)
+	log := logger.F(ctx)
 
 	log.Info("test")
 	log.Sync()

--- a/tests/development_test.go
+++ b/tests/development_test.go
@@ -18,7 +18,7 @@ func TestDevelopmentLogger(t *testing.T) {
 
 	ctx, err := logger.ConfigureDevelopmentLogger(ctx, "info", &output)
 	require.Nil(t, err)
-	log := logger.F(ctx)
+	log := logger.L(ctx)
 
 	log.Info("test")
 	log.Sync()

--- a/tests/production_test.go
+++ b/tests/production_test.go
@@ -18,7 +18,7 @@ func TestProductionLogger(t *testing.T) {
 
 	ctx, err := logger.ConfigureProductionLogger(ctx, "info", &output)
 	require.Nil(t, err)
-	log := logger.FromContext(ctx)
+	log := logger.F(ctx)
 
 	log.Info("test")
 	log.Sync()

--- a/tests/production_test.go
+++ b/tests/production_test.go
@@ -18,7 +18,7 @@ func TestProductionLogger(t *testing.T) {
 
 	ctx, err := logger.ConfigureProductionLogger(ctx, "info", &output)
 	require.Nil(t, err)
-	log := logger.F(ctx)
+	log := logger.L(ctx)
 
 	log.Info("test")
 	log.Sync()

--- a/tests/with_options_test.go
+++ b/tests/with_options_test.go
@@ -18,7 +18,7 @@ func TestWithOptions(t *testing.T) {
 	// create new production logger
 	ctx, err := logger.ConfigureProductionLogger(ctx, "info", &output)
 	require.Nil(t, err)
-	myLogger := logger.FromContext(ctx)
+	myLogger := logger.F(ctx)
 
 	myLogger.NewChild().WithOptions(logger.AddCallerSkip(5))
 }

--- a/tests/with_options_test.go
+++ b/tests/with_options_test.go
@@ -18,7 +18,7 @@ func TestWithOptions(t *testing.T) {
 	// create new production logger
 	ctx, err := logger.ConfigureProductionLogger(ctx, "info", &output)
 	require.Nil(t, err)
-	myLogger := logger.F(ctx)
+	myLogger := logger.L(ctx)
 
 	myLogger.NewChild().WithOptions(logger.AddCallerSkip(5))
 }


### PR DESCRIPTION
## Description

Updated the name of the function to get the logger or tracer to `F()` to make it faster to type.

## Checklist

- [x] I have added one of the `patch`, `minor`, `major` or `no-release` labels
