### PR TITLE
send lambda name & log group info to GlitchTip

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -143,6 +143,11 @@ func (l *logger) captureExceptions(fields []Field) {
 
 		// Provide trace context to sentry
 		sentry.WithScope(func(scope *sentry.Scope) {
+			scope.SetContext("aws", map[string]interface{}{
+				"lambda":    os.Getenv("AWS_LAMBDA_FUNCTION_NAME"),
+				"logGroup":  os.Getenv("AWS_LAMBDA_LOG_GROUP_NAME"),
+				"logStream": os.Getenv("AWS_LAMBDA_LOG_STREAM_NAME"),
+			})
 			scope.SetContext("trace", map[string]interface{}{
 				"traceID": span.SpanContext().TraceID().String(),
 				"spanID":  span.SpanContext().SpanID().String(),


### PR DESCRIPTION
## Description

This is untested, but hopefully it would add lambda function name & cloudwatch log info to GlithTip issue

## Checklist

- [ ] I have added one of the `patch`, `minor`, `major` or `no-release` labels
- [ ] I have linked an issue from this repository using the **Development** option
- [ ] I have performed a self-review of my own code
- [ ] I have checked for redundant or commented out code
- [ ] I have commented my code where I can't make it self-documenting
- [ ] I have made corresponding changes to the documentation
- [ ] I have added any appropriate tests
