### PR TITLE
add generic custom trace header carrier

### DIFF
--- a/pkg/logger/tracer/custom.go
+++ b/pkg/logger/tracer/custom.go
@@ -1,0 +1,70 @@
+package tracer
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+)
+
+type customMessageAttributeCarrier struct {
+	Attributes map[string]string
+}
+
+func (c *customMessageAttributeCarrier) Get(key string) string {
+	return c.Attributes[key]
+}
+
+func (c *customMessageAttributeCarrier) Set(key, value string) {
+	c.Attributes[key] = value
+}
+
+func (c *customMessageAttributeCarrier) Keys() []string {
+	keys := make([]string, 0, len(c.Attributes))
+	for k := range c.Attributes {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+func newCustomMessageCarrier(attributes map[string]string) propagation.TextMapCarrier {
+	return &customMessageAttributeCarrier{Attributes: attributes}
+}
+
+// InjectTracingIntoCustomMessage inserts tracing from context into the Custom message attributes.
+func InjectTracingIntoCustomMessage(ctx context.Context, attributes map[string]string) {
+	if attributes == nil {
+		attributes = make(map[string]string)
+	}
+
+	otel.GetTextMapPropagator().Inject(ctx, newCustomMessageCarrier(attributes))
+}
+
+type customEventMessageAttributeCarrier struct {
+	Attributes map[string]string
+}
+
+func (c *customEventMessageAttributeCarrier) Get(key string) string {
+	return c.Attributes[key]
+}
+
+func (c *customEventMessageAttributeCarrier) Set(key, value string) {
+	c.Attributes[key] = value
+}
+
+func (c *customEventMessageAttributeCarrier) Keys() []string {
+	keys := make([]string, 0, len(c.Attributes))
+	for k := range c.Attributes {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+func newCustomEventMessageCarrier(attributes map[string]string) propagation.TextMapCarrier {
+	return &customEventMessageAttributeCarrier{Attributes: attributes}
+}
+
+// ExtractTracingFromCustomEventMessage extracts tracing from Custom event message attributes.
+func ExtractTracingFromCustomEventMessage(ctx context.Context, attributes map[string]string) context.Context {
+	return otel.GetTextMapPropagator().Extract(ctx, newCustomEventMessageCarrier(attributes))
+}


### PR DESCRIPTION
## Description

add generic custom trace header carrier so we can inject and extract trace ids into any variable of type `map[string]string`.

we need this for things like passing trace ids through step functions where its only our own custom event struct that is passed to the lambdas.

## Checklist

- [ ] I have added one of the `patch`, `minor`, `major` or `no-release` labels
- [ ] I have linked an issue from this repository using the **Development** option
- [ ] I have performed a self-review of my own code
- [ ] I have checked for redundant or commented out code
- [ ] I have commented my code where I can't make it self-documenting
- [ ] I have made corresponding changes to the documentation
- [ ] I have added any appropriate tests
