### PR TITLE
change flush errors to warnings

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -75,7 +75,7 @@ func (l *logger) AddFields(fields ...Field) {
 func (l *logger) Sync() {
 	err := tracer.ForceFlush(l.attachedContext)
 	if err != nil {
-		l.Error("tracer.ForceFlush failed", Err(err))
+		l.Warn("tracer.ForceFlush failed", Err(err))
 	}
 
 	if os.Getenv("SENTRY_DSN") != "" {


### PR DESCRIPTION
## Description

if the flush fails, log a warning not an error

## Checklist

- [ ] I have added one of the `patch`, `minor`, `major` or `no-release` labels
- [ ] I have linked an issue from this repository using the **Development** option
- [ ] I have performed a self-review of my own code
- [ ] I have checked for redundant or commented out code
- [ ] I have commented my code where I can't make it self-documenting
- [ ] I have made corresponding changes to the documentation
- [ ] I have added any appropriate tests
