### PR TITLE
NUL-899-glitchtip-event-enrichment

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22.2
 require go.uber.org/multierr v1.11.0 // indirect
 
 require (
+	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.3 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.27 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.11 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.15 // indirect
@@ -41,6 +42,7 @@ require (
 	github.com/aws/aws-lambda-go v1.47.0
 	github.com/aws/aws-sdk-go-v2 v1.30.3
 	github.com/aws/aws-sdk-go-v2/config v1.27.27
+	github.com/aws/aws-sdk-go-v2/service/lambda v1.56.3
 	github.com/aws/aws-sdk-go-v2/service/sns v1.31.3
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.34.3
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.52.3

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/aws/aws-lambda-go v1.47.0 h1:0H8s0vumYx/YKs4sE7YM0ktwL2eWse+kfopsRI1s
 github.com/aws/aws-lambda-go v1.47.0/go.mod h1:dpMpZgvWx5vuQJfBt0zqBha60q7Dd7RfgJv23DymV8A=
 github.com/aws/aws-sdk-go-v2 v1.30.3 h1:jUeBtG0Ih+ZIFH0F4UkmL9w3cSpaMv9tYYDbzILP8dY=
 github.com/aws/aws-sdk-go-v2 v1.30.3/go.mod h1:nIQjQVp5sfpQcTc9mPSr1B0PaWK5ByX9MOoDadSN4lc=
+github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.3 h1:tW1/Rkad38LA15X4UQtjXZXNKsCgkshC3EbmcUmghTg=
+github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.3/go.mod h1:UbnqO+zjqk3uIt9yCACHJ9IVNhyhOCnYk8yA19SAWrM=
 github.com/aws/aws-sdk-go-v2/config v1.27.27 h1:HdqgGt1OAP0HkEDDShEl0oSYa9ZZBSOmKpdpsDMdO90=
 github.com/aws/aws-sdk-go-v2/config v1.27.27/go.mod h1:MVYamCg76dFNINkZFu4n4RjDixhVr51HLj4ErWzrVwg=
 github.com/aws/aws-sdk-go-v2/credentials v1.17.27 h1:2raNba6gr2IfA0eqqiP2XiQ0UVOpGPgDSi0I9iAP+UI=
@@ -18,6 +20,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.11.3 h1:dT3MqvG
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.11.3/go.mod h1:GlAeCkHwugxdHaueRr4nhPuY+WW+gR8UjlcqzPr1SPI=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.11.17 h1:HGErhhrxZlQ044RiM+WdoZxp0p+EGM62y3L6pwA4olE=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.11.17/go.mod h1:RkZEx4l0EHYDJpWppMJ3nD9wZJAa8/0lq9aVC+r2UII=
+github.com/aws/aws-sdk-go-v2/service/lambda v1.56.3 h1:r/y4nQOln25cbjrD8Wmzhhvnvr2ObPjgcPvPdoU9yHs=
+github.com/aws/aws-sdk-go-v2/service/lambda v1.56.3/go.mod h1:/4Vaddp+wJc1AA8ViAqwWKAcYykPV+ZplhmLQuq3RbQ=
 github.com/aws/aws-sdk-go-v2/service/sns v1.31.3 h1:eSTEdxkfle2G98FE+Xl3db/XAXXVTJPNQo9K/Ar8oAI=
 github.com/aws/aws-sdk-go-v2/service/sns v1.31.3/go.mod h1:1dn0delSO3J69THuty5iwP0US2Glt0mx2qBBlI13pvw=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.34.3 h1:Vjqy5BZCOIsn4Pj8xzyqgGmsSqzz7y/WXbN3RgOoVrc=

--- a/pkg/logger/configure.go
+++ b/pkg/logger/configure.go
@@ -162,7 +162,7 @@ func initialiseSentry() {
 	}
 }
 
-// AddLambdaTagsToSentryEvents() Sets `Environment`, `ServerName` and adds `service`, `tenant` and `region` tags to Sentry events
+// AddLambdaTagsToSentryEvents Sets `Environment`, `ServerName` and adds `service`, `tenant` and `region` tags to Sentry events
 func AddLambdaTagsToSentryEvents(ctx context.Context, awsConfig aws.Config) error {
 	lambdaClient := lambda.NewFromConfig(awsConfig)
 

--- a/pkg/logger/configure.go
+++ b/pkg/logger/configure.go
@@ -162,6 +162,7 @@ func initialiseSentry() {
 	}
 }
 
+// AddLambdaTagsToSentryEvents() Sets `Environment`, `ServerName` and adds `service`, `tenant` and `region` tags to Sentry events
 func AddLambdaTagsToSentryEvents(ctx context.Context, awsConfig aws.Config) error {
 	lambdaClient := lambda.NewFromConfig(awsConfig)
 
@@ -175,7 +176,7 @@ func AddLambdaTagsToSentryEvents(ctx context.Context, awsConfig aws.Config) erro
 	}
 
 	// called by client.CaptureEvent() -> .processEvent() -> .prepareEvent()
-	sentry.CurrentHub().Client().AddEventProcessor(func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+	sentry.CurrentHub().Client().AddEventProcessor(func(event *sentry.Event, _ *sentry.EventHint) *sentry.Event {
 		event.Environment = functionDetails.Tags["Environment"]
 		event.ServerName = os.Getenv("AWS_LAMBDA_FUNCTION_NAME")
 		event.Tags["service"] = functionDetails.Tags["Service"]

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -12,7 +12,7 @@ func TestFormatLogsURL(t *testing.T) {
 	logStreamName := "2024/07/22/[$LATEST]83b2196b0fb5466e9e71f9e6c9eceab8"
 
 	expectedURL := "https://ap-southeast-2.console.aws.amazon.com/cloudwatch/home?region=ap-southeast-2#logsV2:log-groups/log-group/" +
-		"$252Faws$252Flambda$252Ffoxsports-the-force-pullrequest/log-events/" + 
+		"$252Faws$252Flambda$252Ffoxsports-the-force-pullrequest/log-events/" +
 		"2024$252F07$252F22$252F$255B$2524LATEST$255D83b2196b0fb5466e9e71f9e6c9eceab8"
 
 	result := formatLogsURL(region, logGroupName, logStreamName)

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -1,0 +1,21 @@
+package logger
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatLogsURL(t *testing.T) {
+	region := "ap-southeast-2"
+	logGroupName := "/aws/lambda/foxsports-the-force-pullrequest"
+	logStreamName := "2024/07/22/[$LATEST]83b2196b0fb5466e9e71f9e6c9eceab8"
+
+	expectedURL := "https://ap-southeast-2.console.aws.amazon.com/cloudwatch/home?region=ap-southeast-2#logsV2:log-groups/log-group/" +
+		"$252Faws$252Flambda$252Ffoxsports-the-force-pullrequest/log-events/" + 
+		"2024$252F07$252F22$252F$255B$2524LATEST$255D83b2196b0fb5466e9e71f9e6c9eceab8"
+
+	result := formatLogsURL(region, logGroupName, logStreamName)
+
+	require.Equal(t, expectedURL, result)
+}


### PR DESCRIPTION
## Description

call `logger.AddLambdaTagsToSentryEvents(ctx, awsConfig)` to configure 
- Environment
- ServerName
- service, tenant & region tags

## Linked Issues & PRs

- resolves https://linear.app/nullify-ai/issue/NUL-899/glitchtip-event-enrichment


## Checklist

- [x] I have added one of the `patch`, `minor`, `major` or `no-release` labels
- [ ] I have linked an issue from this repository using the **Development** option
- [ ] I have performed a self-review of my own code
- [ ] I have checked for redundant or commented out code
- [ ] I have commented my code where I can't make it self-documenting
- [ ] I have made corresponding changes to the documentation
- [x] I have added any appropriate tests
