### PR TITLE
add more sentry tags

### DIFF
--- a/pkg/logger/configure.go
+++ b/pkg/logger/configure.go
@@ -178,10 +178,14 @@ func AddLambdaTagsToSentryEvents(ctx context.Context, awsConfig aws.Config) erro
 	// called by client.CaptureEvent() -> .processEvent() -> .prepareEvent()
 	sentry.CurrentHub().Client().AddEventProcessor(func(event *sentry.Event, _ *sentry.EventHint) *sentry.Event {
 		event.Environment = functionDetails.Tags["Environment"]
-		event.ServerName = os.Getenv("AWS_LAMBDA_FUNCTION_NAME")
-		event.Tags["service"] = functionDetails.Tags["Service"]
-		event.Tags["tenant"] = functionDetails.Tags["Tenant"]
+		event.ServerName = functionName
+
+		event.Tags["environment"] = functionDetails.Tags["Environment"]
 		event.Tags["region"] = os.Getenv("AWS_REGION")
+		event.Tags["tenant"] = functionDetails.Tags["Tenant"]
+		event.Tags["service"] = functionDetails.Tags["Service"]
+		event.Tags["function"] = functionName
+
 		return event
 	})
 


### PR DESCRIPTION
## Description

add more sentry tags.
environment and function name.
these are important to just see prod errors or see errors specifically for key lambdas like the sast lambda.

## Checklist

- [ ] I have added one of the `patch`, `minor`, `major` or `no-release` labels
- [ ] I have linked an issue from this repository using the **Development** option
- [ ] I have performed a self-review of my own code
- [ ] I have checked for redundant or commented out code
- [ ] I have commented my code where I can't make it self-documenting
- [ ] I have made corresponding changes to the documentation
- [ ] I have added any appropriate tests
