### PR TITLE
fixed sentry "mechanism type required" error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.28.0 // indirect
 	go.opentelemetry.io/otel/metric v1.28.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,6 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.28.0 // indirect
 	go.opentelemetry.io/otel/metric v1.28.0 // indirect
@@ -48,6 +47,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.34.3
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.52.3
 	github.com/getsentry/sentry-go v0.28.1
+	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/otel v1.28.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.28.0

--- a/pkg/logger/configure.go
+++ b/pkg/logger/configure.go
@@ -201,7 +201,6 @@ func addTagsToSentryEvents(functionName string, tags map[string]string) {
 func fixMechanismTypeInSentryEvents() {
 	// called by client.CaptureEvent() -> .processEvent() -> .prepareEvent()
 	sentry.CurrentHub().Client().AddEventProcessor(func(event *sentry.Event, _ *sentry.EventHint) *sentry.Event {
-
 		for i := range event.Exception {
 			if event.Exception[i].Mechanism != nil && event.Exception[i].Mechanism.Type == "" {
 				// avoid "list[function-after[check_type_value(), function-wrap[_run_root_validator()]]]",

--- a/pkg/logger/configure.go
+++ b/pkg/logger/configure.go
@@ -160,6 +160,8 @@ func initialiseSentry() {
 		zap.L().Error("failed to initialise sentry", zap.Error(err))
 		return
 	}
+
+	fixMechanismTypeInSentryEvents()
 }
 
 // AddLambdaTagsToSentryEvents Sets `Environment`, `ServerName` and adds `service`, `tenant` and `region` tags to Sentry events
@@ -175,21 +177,40 @@ func AddLambdaTagsToSentryEvents(ctx context.Context, awsConfig aws.Config) erro
 		return err
 	}
 
+	addTagsToSentryEvents(functionName, functionDetails.Tags)
+
+	return nil
+}
+
+func addTagsToSentryEvents(functionName string, tags map[string]string) {
 	// called by client.CaptureEvent() -> .processEvent() -> .prepareEvent()
 	sentry.CurrentHub().Client().AddEventProcessor(func(event *sentry.Event, _ *sentry.EventHint) *sentry.Event {
-		event.Environment = functionDetails.Tags["Environment"]
+		event.Environment = tags["Environment"]
 		event.ServerName = functionName
 
-		event.Tags["environment"] = functionDetails.Tags["Environment"]
+		event.Tags["environment"] = tags["Environment"]
 		event.Tags["region"] = os.Getenv("AWS_REGION")
-		event.Tags["tenant"] = functionDetails.Tags["Tenant"]
-		event.Tags["service"] = functionDetails.Tags["Service"]
+		event.Tags["tenant"] = tags["Tenant"]
+		event.Tags["service"] = tags["Service"]
 		event.Tags["function"] = functionName
 
 		return event
 	})
+}
 
-	return nil
+func fixMechanismTypeInSentryEvents() {
+	// called by client.CaptureEvent() -> .processEvent() -> .prepareEvent()
+	sentry.CurrentHub().Client().AddEventProcessor(func(event *sentry.Event, _ *sentry.EventHint) *sentry.Event {
+
+		for i := range event.Exception {
+			if event.Exception[i].Mechanism != nil && event.Exception[i].Mechanism.Type == "" {
+				// avoid "list[function-after[check_type_value(), function-wrap[_run_root_validator()]]]",
+				event.Exception[i].Mechanism.Type = "error"
+			}
+		}
+
+		return event
+	})
 }
 
 func getSecretFromParamStore(varName string) *string {


### PR DESCRIPTION
## Description

fix for 

```
[Sentry] 2024/07/23 04:45:20 Sending event failed with the following error: 
{
    "detail": [
        {
            "type": "missing",
            "loc": [
                "body",
                "payload",
                "exception",
                "list[function-after[check_type_value(), function-wrap[_run_root_validator()]]]",
                0,
                "mechanism",
                "type"
            ],
            "msg": "Field required"
        },
```

https://ap-southeast-2.console.aws.amazon.com/cloudwatch/home?region=ap-southeast-2#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fnullify-dev-the-sith-api/log-events/2024$252F07$252F23$252F$255B$2524LATEST$255D20d22a93737743358992f8967556b7ee

## Checklist

- [ ] I have added one of the `patch`, `minor`, `major` or `no-release` labels
- [ ] I have linked an issue from this repository using the **Development** option
- [ ] I have performed a self-review of my own code
- [ ] I have checked for redundant or commented out code
- [ ] I have commented my code where I can't make it self-documenting
- [ ] I have made corresponding changes to the documentation
- [ ] I have added any appropriate tests
