### PR TITLE
silently fail if AWS_LAMBDA_FUNCTION_NAME is empty

### DIFF
--- a/pkg/logger/configure.go
+++ b/pkg/logger/configure.go
@@ -173,15 +173,17 @@ func AddLambdaTagsToSentryEvents(ctx context.Context, awsConfig aws.Config) erro
 	lambdaClient := lambda.NewFromConfig(awsConfig)
 
 	functionName := os.Getenv("AWS_LAMBDA_FUNCTION_NAME")
-	functionDetails, err := lambdaClient.GetFunction(ctx, &lambda.GetFunctionInput{
-		FunctionName: aws.String(functionName),
-	})
-	if err != nil {
-		zap.L().Error("failed to get lambda function details", zap.Error(err))
-		return err
-	}
+	if functionName != "" {
+		functionDetails, err := lambdaClient.GetFunction(ctx, &lambda.GetFunctionInput{
+			FunctionName: aws.String(functionName),
+		})
+		if err != nil {
+			zap.L().Error("failed to get lambda function details", zap.Error(err))
+			return err
+		}
 
-	addTagsToSentryEvents(functionName, os.Getenv("AWS_REGION"), functionDetails.Tags)
+		addTagsToSentryEvents(functionName, os.Getenv("AWS_REGION"), functionDetails.Tags)
+	}
 
 	return nil
 }


### PR DESCRIPTION
## Description

silently fail if AWS_LAMBDA_FUNCTION_NAME is empty

## Checklist

- [x] I have added one of the `patch`, `minor`, `major` or `no-release` labels
- [ ] I have linked an issue from this repository using the **Development** option
- [ ] I have performed a self-review of my own code
- [ ] I have checked for redundant or commented out code
- [ ] I have commented my code where I can't make it self-documenting
- [ ] I have made corresponding changes to the documentation
- [ ] I have added any appropriate tests
