### PR TITLE
Allow API handlers to start new root span 

### DIFF
--- a/pkg/logger/tracer/tracer.go
+++ b/pkg/logger/tracer/tracer.go
@@ -8,13 +8,21 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-type tracerCtxKey struct{}
-type traceProviderCtxKey struct{}
+type (
+	tracerCtxKey        struct{}
+	traceProviderCtxKey struct{}
+)
 
 // FromContext returns the tracer from the context
 func FromContext(ctx context.Context) trace.Tracer {
 	t, _ := ctx.Value(tracerCtxKey{}).(trace.Tracer)
 	return t
+}
+
+// StartNewRootSpan should be called at from API handlers to start a new root span for each request
+func StartNewRootSpan(ctx context.Context, spanName string) (context.Context, trace.Span) {
+	t := FromContext(ctx)
+	return t.Start(ctx, spanName, trace.WithNewRoot())
 }
 
 // CopyFromContext copies the tracer from the old context to the new context

--- a/pkg/logger/tracer/tracer.go
+++ b/pkg/logger/tracer/tracer.go
@@ -19,10 +19,25 @@ func FromContext(ctx context.Context) trace.Tracer {
 	return t
 }
 
-// StartNewRootSpan should be called at from API handlers to start a new root span for each request
-func StartNewRootSpan(ctx context.Context, spanName string) (context.Context, trace.Span) {
+// StartNewSpan loads the Tracer from the context and starts a new span.
+// opts can be used to provide additional options to t.Start():
+//   - trace.WithAttributes()
+//   - trace.WithSpanKind(trace.SpanKindServer)  or Internal/Client/Producer/Consumer
+//   - trace.WithLinks({SpanContext, Attributes})
+//   - trace.WithStackTrace(true)
+func StartNewSpan(ctx context.Context, spanName string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
 	t := FromContext(ctx)
-	return t.Start(ctx, spanName, trace.WithNewRoot())
+	return t.Start(ctx, spanName, opts...)
+}
+
+// StartNewRootSpan should be called at from API handlers to start a new root span for each request.
+// opts can be used to provide additional options to t.Start():
+//   - trace.WithAttributes()
+//   - trace.WithSpanKind(trace.SpanKindServer)  or Internal/Client/Producer/Consumer
+//   - trace.WithLinks({SpanContext, Attributes})
+//   - trace.WithStackTrace(true)
+func StartNewRootSpan(ctx context.Context, spanName string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+	return StartNewSpan(ctx, spanName, append(opts, trace.WithNewRoot())...)
 }
 
 // CopyFromContext copies the tracer from the old context to the new context


### PR DESCRIPTION
## Description

Currently we have one ongoing trace created by the API lambda, which is appended to for each request. 
![image](https://github.com/user-attachments/assets/da044174-aebf-4af1-8df6-8a7ba555e883)
![image](https://github.com/user-attachments/assets/dd66afe3-527d-48eb-9a4a-1b9509822f66)

This also seems to be the case for Docker images:
![image](https://github.com/user-attachments/assets/5ad96463-e1b6-4daf-9324-aa8e0490e97e)


## Checklist

- [x] I have added one of the `patch`, `minor`, `major` or `no-release` labels
- [ ] I have linked an issue from this repository using the **Development** option
- [ ] I have performed a self-review of my own code
- [ ] I have checked for redundant or commented out code
- [ ] I have commented my code where I can't make it self-documenting
- [ ] I have made corresponding changes to the documentation
- [ ] I have added any appropriate tests
