### PR TITLE
add record error to the logger package

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -3,6 +3,7 @@ package logger
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -109,6 +110,7 @@ func (l *logger) Warn(msg string, fields ...Field) {
 
 // Error logs a message with the error level
 func (l *logger) Error(msg string, fields ...Field) {
+	trace.SpanFromContext(l.attachedContext).RecordError(errors.New(msg))
 	trace.SpanFromContext(l.attachedContext).SetStatus(codes.Error, msg)
 	l.captureExceptions(fields)
 	l.underlyingLogger.Error(msg, fields...)


### PR DESCRIPTION
## Description
Adding **RecordError**
Associates the error with the span, making it visible in distributed trace viewers like Jaeger, Grafana Tempo, or AWS X-Ray.
Probs we will have to make the `description` in SetStatus but more generic and be consise
Like `API Error`, `Scan Error` etc.,