### PR TITLE
add full file path to caller

### DIFF
--- a/pkg/logger/configure.go
+++ b/pkg/logger/configure.go
@@ -95,9 +95,23 @@ func ConfigureProductionLogger(ctx context.Context, level string, syncs ...io.Wr
 		sync = syncs[0]
 	}
 
+	encoderConfig := zapcore.EncoderConfig{
+		TimeKey:        "timestamp",
+		LevelKey:       "level",
+		NameKey:        "logger",
+		CallerKey:      "caller",
+		MessageKey:     "msg",
+		StacktraceKey:  "stacktrace",
+		LineEnding:     zapcore.DefaultLineEnding,
+		EncodeLevel:    zapcore.LowercaseLevelEncoder,
+		EncodeTime:     zapcore.ISO8601TimeEncoder,
+		EncodeDuration: zapcore.StringDurationEncoder,
+		EncodeCaller:   zapcore.FullCallerEncoder,
+	}
+
 	zapLogger := zap.New(
 		zapcore.NewCore(
-			zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
+			zapcore.NewJSONEncoder(encoderConfig),
 			zapcore.AddSync(sync),
 			zapLevel,
 		),

--- a/tests/production_test.go
+++ b/tests/production_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/nullify-platform/logger/pkg/logger"
@@ -31,6 +32,10 @@ func TestProductionLogger(t *testing.T) {
 
 	assert.Equal(t, "info", jsonOutput["level"], "stdout didn't include INFO")
 	assert.Equal(t, "test", jsonOutput["msg"], "stdout didn't include the 'test' log message")
-	assert.Equal(t, "tests/production_test.go:23", jsonOutput["caller"], "stdout didn't include the file path and line number")
+
+	pwd, err := os.Getwd()
+	assert.NoError(t, err, "did not get working directory successfully")
+	assert.Equal(t, pwd+"/production_test.go:24", jsonOutput["caller"], "stdout didn't include the file path and line number")
+
 	assert.Equal(t, "0.0.0", jsonOutput["version"], "stdout didn't include version")
 }


### PR DESCRIPTION
## Description

- re-raising a PR for jono/tim's existing work
- shows the full path of the file on the filesystem (virtual or otherwise), e.g.
  - instead of `tests/production_test.go:23`,
  - `/home/runner/work/Logger/Logger/tests/production_test.go:23`
- can help with debugging aws env issues 

## Test Plan

Please include steps to test the change. Include screenshots if applicable.

## Linked Issues & PRs

- resolves <insert-issue-link>
- relates to <insert-pr-link>

[GitHub Issue Linking Docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)

## Checklist

- [ ] I have added one of the `patch`, `minor`, `major` or `no-release` labels
- [ ] I have linked an issue from this repository using the **Development** option
- [ ] I have performed a self-review of my own code
- [ ] I have checked for redundant or commented out code
- [ ] I have commented my code where I can't make it self-documenting
- [ ] I have made corresponding changes to the documentation
- [ ] I have added any appropriate tests
