### PR TITLE
add struct based logic for the logger package

### DIFF
--- a/pkg/logger/configure.go
+++ b/pkg/logger/configure.go
@@ -25,6 +25,8 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
 // Version is the current version of the application
@@ -93,9 +95,23 @@ func ConfigureProductionLogger(ctx context.Context, spanName string, level strin
 		sync = syncs[0]
 	}
 
+	encoderConfig := zapcore.EncoderConfig{
+		TimeKey:        "timestamp",
+		LevelKey:       "level",
+		NameKey:        "logger",
+		CallerKey:      "caller",
+		MessageKey:     "msg",
+		StacktraceKey:  "stacktrace",
+		LineEnding:     zapcore.DefaultLineEnding,
+		EncodeLevel:    zapcore.LowercaseLevelEncoder,
+		EncodeTime:     zapcore.ISO8601TimeEncoder,
+		EncodeDuration: zapcore.StringDurationEncoder,
+		EncodeCaller:   zapcore.FullCallerEncoder,
+	}
+
 	zapLogger := zap.New(
 		zapcore.NewCore(
-			zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
+			zapcore.NewJSONEncoder(encoderConfig),
 			zapcore.AddSync(sync),
 			zapLevel,
 		),

--- a/pkg/logger/configure.go
+++ b/pkg/logger/configure.go
@@ -22,7 +22,6 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
-	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
@@ -83,7 +82,7 @@ func ConfigureDevelopmentLogger(ctx context.Context, level string, syncs ...io.W
 }
 
 // ConfigureProductionLogger configures a JSON production logger
-func ConfigureProductionLogger(ctx context.Context, spanName string, level string, syncs ...io.Writer) (context.Context, trace.Span, error) {
+func ConfigureProductionLogger(ctx context.Context, level string, syncs ...io.Writer) (context.Context, error) {
 	zapLevel, err := zapcore.ParseLevel(level)
 	if err != nil {
 		zap.L().Error("failed to parse log level, using info", zap.Error(err))
@@ -130,7 +129,7 @@ func ConfigureProductionLogger(ctx context.Context, spanName string, level strin
 
 	tp, err := newTraceProvider(traceExporter)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	otel.SetTracerProvider(tp)
@@ -140,8 +139,7 @@ func ConfigureProductionLogger(ctx context.Context, spanName string, level strin
 	l := &logger{underlyingLogger: zapLogger}
 	ctx = l.InjectIntoContext(ctx)
 	ctx = tracer.NewContext(ctx, tp, "prod-logger-tracer")
-	ctx, span := NewNullifyContext(ctx, spanName)
-	return ctx, span, nil
+	return ctx, nil
 }
 
 func newTraceProvider(exp sdktrace.SpanExporter) (*sdktrace.TracerProvider, error) {

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -36,6 +36,11 @@ type Logger interface {
 	// context
 	InjectIntoContext(ctx context.Context) context.Context
 	PassContext(ctx context.Context)
+
+	// nullify context
+	// GetNullifyContext(ctx context.Context) *NullifyContext
+	// SetMetadataForLoggingConfig(newLoggingConfig *LogConfig)
+	SetSpanAttributes(spanName string)
 }
 
 type logger struct {
@@ -94,18 +99,20 @@ func (l *logger) Sync() {
 
 // Debug logs a message with the debug level
 func (l *logger) Debug(msg string, fields ...Field) {
-	l.underlyingLogger.Debug(msg, fields...)
+	updateFields := l.getContextMetadataAsFields(fields)
+	l.underlyingLogger.Debug(msg, updateFields...)
 }
 
 // Info logs a message with the info level
 func (l *logger) Info(msg string, fields ...Field) {
-	l.underlyingLogger.Info(msg, fields...)
+	updateFields := l.getContextMetadataAsFields(fields)
+	l.underlyingLogger.Info(msg, updateFields...)
 }
 
 // Warn logs a message with the warn level
 func (l *logger) Warn(msg string, fields ...Field) {
 	l.captureExceptions(fields)
-	updateFields := l.getContextMetadataAsFields(LogConfig{}, fields)
+	updateFields := l.getContextMetadataAsFields(fields)
 	l.underlyingLogger.Warn(msg, updateFields...)
 }
 
@@ -114,7 +121,7 @@ func (l *logger) Error(msg string, fields ...Field) {
 	trace.SpanFromContext(l.attachedContext).RecordError(errors.New(msg))
 	trace.SpanFromContext(l.attachedContext).SetStatus(codes.Error, msg)
 	l.captureExceptions(fields)
-	updateFields := l.getContextMetadataAsFields(LogConfig{}, fields)
+	updateFields := l.getContextMetadataAsFields(fields)
 	l.underlyingLogger.Error(msg, updateFields...)
 }
 
@@ -122,7 +129,7 @@ func (l *logger) Error(msg string, fields ...Field) {
 func (l *logger) Fatal(msg string, fields ...Field) {
 	trace.SpanFromContext(l.attachedContext).SetStatus(codes.Error, msg)
 	l.captureExceptions(fields)
-	updateFields := l.getContextMetadataAsFields(LogConfig{}, fields)
+	updateFields := l.getContextMetadataAsFields(fields)
 	l.Sync()
 
 	l.underlyingLogger.Fatal(msg, updateFields...)

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -37,9 +37,6 @@ type Logger interface {
 	InjectIntoContext(ctx context.Context) context.Context
 	PassContext(ctx context.Context)
 
-	// nullify context
-	// GetNullifyContext(ctx context.Context) *NullifyContext
-	// SetMetadataForLoggingConfig(newLoggingConfig *LogConfig)
 	SetSpanAttributes(spanName string)
 }
 

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -37,7 +37,7 @@ type Logger interface {
 	InjectIntoContext(ctx context.Context) context.Context
 	PassContext(ctx context.Context)
 
-	SetSpanAttributes(spanName string)
+	SetSpanAttributes(spanName string) context.Context
 }
 
 type logger struct {

--- a/pkg/logger/nullify_context.go
+++ b/pkg/logger/nullify_context.go
@@ -2,92 +2,122 @@ package logger
 
 import (
 	"context"
-
 	"reflect"
+	"strings"
+	"unicode"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/nullify-platform/logger/pkg/logger/tracer"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
 
+// Define custom context key type to avoid collisions
+type nullifyContextKeyType string
+
+const nullifyContextKey nullifyContextKeyType = "NullifyContext"
+
+// NullifyContext holds a mutable tree of BotActions and other useful data
+type NullifyContext struct {
+	AWSConfig   aws.Config
+	Span        trace.Span
+	LogConfig   LogConfig
+	TraceConfig TraceConfig
+}
+
+// LogConfig holds configuration for logging
 type LogConfig struct {
-	Repository *repository
-	Service    *service
-	Tool       *tool
+	Repository Repository
+	Service    Service
+	Tool       Tool
+	Platform   Platform
 }
 
-type repository struct {
-	Name           *string `json:"repository_name"`
-	Owner          *string `json:"repository_owner"`
-	Platform       *string `json:"platform"`
-	ID             *string `json:"repository_id"`
-	CommitID       *string `json:"commit_id"` //head commit id
-	PRNumber       *string `json:"pr_number"`
-	Component      *string `json:"component"`
-	BranchID       *string `json:"branch_id"`
-	BranchName     *string `json:"branch_name"`
-	InstallationID *string `json:"installation_id"`
-	AppID          *string `json:"app_id"`
-	Action         *string `json:"action"`
-	ProjectID      *string `json:"project_id"`
-	OrganizationID *string `json:"organization_id"`
-	CloneURL       *string `json:"clone_url"`
-	StartCommitSha *string `json:"start_commit_sha"`
-	EndCommitSha   *string `json:"end_commit_sha"`
+// Platform holds platform-specific information
+type Platform struct {
+	Name      string `json:"platform_name"`
+	Component string `json:"platform_component"`
 }
 
-type service struct {
-	Name            *string `json:"service_name"`
-	ServiceCategory *string `json:"service_category"`
-	Event           *string `json:"service_event"`
+// TraceConfig holds tracing configuration
+type TraceConfig struct {
+	SpanName string `json:"span_name"`
+	Span     trace.Span
 }
 
-type tool struct {
-	Name   *string `json:"tool_name"`
-	Status *string `json:"tool_status"`
+// Repository holds repository-specific information
+type Repository struct {
+	Name           string `json:"repository_name"`
+	Owner          string `json:"repository_owner"`
+	ID             string `json:"repository_id"`
+	CommitID       string `json:"commit_id"`
+	PrNumber       string `json:"pr_number"`
+	BranchID       string `json:"branch_id"`
+	BranchName     string `json:"branch_name"`
+	InstallationID string `json:"installation_id"`
+	AppID          string `json:"app_id"`
+	Action         string `json:"action"`
+	ProjectID      string `json:"project_id"`
+	OrganizationID string `json:"organization_id"`
+	StartCommitSha string `json:"start_commit_sha"`
+	EndCommitSha   string `json:"end_commit_sha"`
+	CloneURL       string `json:"clone_url"`
 }
 
+// Service holds service-specific information
+type Service struct {
+	Name     string `json:"service_name"`
+	Category string `json:"service_category"`
+	Event    string `json:"service_event"`
+}
+
+// Tool holds tool-specific information
+type Tool struct {
+	Name   string `json:"tool_name"`
+	Status string `json:"tool_status"`
+}
+
+// GetNullifyContext creates a new NullifyContext if one does not already exist in the context.
+func GetNullifyContext(ctx context.Context) (context.Context, *NullifyContext) {
+	if nullifyContext, ok := ctx.Value(nullifyContextKey).(*NullifyContext); ok {
+		return ctx, nullifyContext
+	} else {
+		nullifyContext = &NullifyContext{}
+		ctx, span := tracer.StartNewRootSpan(ctx, "context.InitializeNullifyContext")
+		nullifyContext.Span = span
+		return context.WithValue(ctx, nullifyContextKey, nullifyContext), nullifyContext
+	}
+}
+
+// GetAWSConfig retrieves the AWS configuration from the context or loads it if not present
+func GetAWSConfig(ctx context.Context) (aws.Config, error) {
+	_, nullifyContext := GetNullifyContext(ctx)
+
+	if nullifyContext.AWSConfig.Region == "" {
+		awsConfig, err := config.LoadDefaultConfig(ctx)
+		if err != nil {
+			L(ctx).Error("error loading AWS config", Err(err))
+			return aws.Config{}, err
+		}
+
+		nullifyContext.AWSConfig = awsConfig
+	}
+
+	return nullifyContext.AWSConfig, nil
+}
+
+// contextKey is a custom type for context keys
 type contextKey string
 
-func SetMetadata(ctx context.Context, metadata map[string]string) context.Context {
-	for key, value := range metadata {
-		ctx = setContextMetadata(ctx, contextKey(key), value)
-	}
-	return ctx
+// getContextMetadataAsFields extracts fields from the attached context
+func (l *logger) getContextMetadataAsFields(fields []zapcore.Field) []zapcore.Field {
+	return extractFieldsFromStruct(l.attachedContext, reflect.ValueOf(LogConfig{}), fields)
 }
 
-func setContextMetadata(ctx context.Context, inputKey contextKey, inputValue string) context.Context {
-	return context.WithValue(ctx, contextKey(inputKey), inputValue)
-}
-
-func SetTraceAttributes(trace trace.Span, metadata map[string]string) trace.Span {
-	for key, value := range metadata {
-		trace.SetAttributes(attribute.String(key, value))
-	}
-	return trace
-}
-
-func GetAWSConfig(ctx context.Context) (aws.Config, error) {
-	awsConfig, err := config.LoadDefaultConfig(ctx)
-	if err != nil {
-		return aws.Config{}, err
-	}
-	return awsConfig, nil
-}
-
-func SetMetdataForLogsAndTraces(ctx context.Context, trace trace.Span, metadata map[string]string) (context.Context, trace.Span) {
-	mctx := SetMetadata(ctx, metadata)
-	mtrace := SetTraceAttributes(trace, metadata)
-	return mctx, mtrace
-}
-
-func (l *logger) getContextMetadataAsFields(logConfig LogConfig, fields []zapcore.Field) []zapcore.Field {
-	return extractFieldsFromStruct(l.attachedContext, reflect.ValueOf(logConfig), fields)
-}
-
+// extractFieldsFromStruct extracts fields from a struct and appends them as zap fields
 func extractFieldsFromStruct(ctx context.Context, v reflect.Value, fields []zapcore.Field) []zapcore.Field {
 	if v.Kind() == reflect.Ptr {
 		v = v.Elem()
@@ -121,9 +151,70 @@ func extractFieldsFromStruct(ctx context.Context, v reflect.Value, fields []zapc
 		key := contextKey(field.Name)
 		if value, ok := ctx.Value(key).(string); ok {
 			// Append zap field
-			fields = append(fields, zap.String(jsonKey, value))
+			fields = append(fields, zap.String(snakeToCamel(jsonKey), value))
 		}
 	}
 
 	return fields
+}
+
+// snakeToCamel converts snake_case to camelCase
+func snakeToCamel(s string) string {
+	parts := strings.Split(s, "_")
+	for i := 1; i < len(parts); i++ {
+		r := []rune(parts[i])
+		if len(r) > 0 {
+			r[0] = unicode.ToTitle(r[0])
+			parts[i] = string(r)
+		}
+	}
+	return strings.Join(parts, "")
+}
+
+// SetSpanAttributes sets attributes on the current span based on the LogConfig
+func (l *logger) SetSpanAttributes(spanName string) {
+	nullifyContext := l.attachedContext.Value(nullifyContextKey).(*NullifyContext)
+	l.attachedContext, nullifyContext.Span = tracer.StartNewSpan(l.attachedContext, spanName)
+	defer nullifyContext.Span.End()
+	if nullifyContext.TraceConfig.SpanName != "" {
+		v := reflect.ValueOf(nullifyContext.LogConfig)
+		t := v.Type()
+		for i := 0; i < v.NumField(); i++ {
+			field := v.Field(i)
+			fieldType := t.Field(i)
+			nullifyContext.Span.SetAttributes(attribute.String(snakeToCamel(fieldType.Name), field.Kind().String()))
+			// If the field is a struct, recurse into it
+			if field.Kind() == reflect.Struct {
+				l.setStructAttributes(field)
+				continue
+			}
+
+			jsonKey := fieldType.Tag.Get("json")
+			if jsonKey == "" || jsonKey == "-" {
+				continue
+			}
+
+			nullifyContext.Span.SetAttributes(attribute.String(snakeToCamel(jsonKey), field.String()))
+		}
+	}
+}
+
+// setStructAttributes sets attributes for struct fields recursively
+func (l *logger) setStructAttributes(v reflect.Value) {
+	t := v.Type()
+	nullifyContext := l.attachedContext.Value(nullifyContextKey).(*NullifyContext)
+	for i := 0; i < v.NumField(); i++ {
+		field := v.Field(i)
+		fieldType := t.Field(i)
+		// If the field is a struct, recurse into it
+		if field.Kind() == reflect.Struct {
+			l.setStructAttributes(field)
+			continue
+		}
+		jsonKey := fieldType.Tag.Get("json")
+		if jsonKey == "" || jsonKey == "-" {
+			continue
+		}
+		nullifyContext.Span.SetAttributes(attribute.String(snakeToCamel(jsonKey), field.String()))
+	}
 }

--- a/pkg/logger/nullify_context.go
+++ b/pkg/logger/nullify_context.go
@@ -3,8 +3,6 @@ package logger
 import (
 	"context"
 	"reflect"
-	"strings"
-	"unicode"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -37,42 +35,43 @@ type LogConfig struct {
 
 // Platform holds platform-specific information
 type Platform struct {
-	Name      string `json:"platform_name"`
-	Component string `json:"platform_component"`
+	Name      string `json:"platformName"`
+	Component string `json:"platformComponent"`
 }
 
 // TraceConfig holds tracing configuration
 
 // Repository holds repository-specific information
 type Repository struct {
-	Name           string `json:"repository_name"`
-	Owner          string `json:"repository_owner"`
-	ID             string `json:"repository_id"`
-	CommitID       string `json:"commit_id"`
-	PrNumber       string `json:"pr_number"`
-	BranchID       string `json:"branch_id"`
-	BranchName     string `json:"branch_name"`
-	InstallationID string `json:"installation_id"`
-	AppID          string `json:"app_id"`
+	Name           string `json:"repositoryName"`
+	Owner          string `json:"repositoryOwner"`
+	ID             string `json:"repositoryId"`
+	CommitID       string `json:"commitId"`
+	PrNumber       string `json:"prNumber"`
+	BranchID       string `json:"branchId"`
+	BranchName     string `json:"branchName"`
+	InstallationID string `json:"installationId"`
+	AppID          string `json:"appId"`
 	Action         string `json:"action"`
-	ProjectID      string `json:"project_id"`
-	OrganizationID string `json:"organization_id"`
-	StartCommitSha string `json:"start_commit_sha"`
-	EndCommitSha   string `json:"end_commit_sha"`
-	CloneURL       string `json:"clone_url"`
+	ProjectName    string `json:"projectName"`
+	ProjectID      string `json:"projectId"`
+	OrganizationID string `json:"organizationId"`
+	StartCommitSha string `json:"startCommitSha"`
+	EndCommitSha   string `json:"endCommitSha"`
+	CloneURL       string `json:"cloneUrl"`
 }
 
 // Service holds service-specific information
 type Service struct {
-	Name     string `json:"service_name"`
-	Category string `json:"service_category"`
-	Event    string `json:"service_event"`
+	Name     string `json:"serviceName"`
+	Category string `json:"serviceCategory"`
+	Event    string `json:"serviceEvent"`
 }
 
 // Tool holds tool-specific information
 type Tool struct {
-	Name   string `json:"tool_name"`
-	Status string `json:"tool_status"`
+	Name   string `json:"toolName"`
+	Status string `json:"toolStatus"`
 }
 
 // GetNullifyContext creates a new NullifyContext if one does not already exist in the context.
@@ -146,25 +145,37 @@ func extractFieldsFromStruct(ctx context.Context, v reflect.Value, fields []zapc
 		key := contextKey(field.Name)
 		if value, ok := ctx.Value(key).(string); ok && value != "" {
 			// Append zap field
-			fields = append(fields, zap.String(snakeToCamel(jsonKey), value))
+			fields = append(fields, zap.String(jsonKey, value))
 		}
 	}
 
 	return fields
 }
 
-// snakeToCamel converts snake_case to camelCase
-func snakeToCamel(s string) string {
-	parts := strings.Split(s, "_")
-	for i := 1; i < len(parts); i++ {
-		r := []rune(parts[i])
-		if len(r) > 0 {
-			r[0] = unicode.ToTitle(r[0])
-			parts[i] = string(r)
-		}
-	}
-	return strings.Join(parts, "")
-}
+// TODO: This is a temporary function to get the function name. We need to fine tune it to get the function name as there are some edge cases and we need to handle them
+// func (l *logger) getFunctionName() string {
+// 	pc, _, _, _ := runtime.Caller(2)
+// 	fullName := runtime.FuncForPC(pc).Name()
+
+// 	// Step 1: Remove full module and directory path
+// 	if lastSlash := strings.LastIndex(fullName, "/"); lastSlash != -1 {
+// 		fullName = fullName[lastSlash+1:] // Keep only package and function parts
+// 	}
+
+// 	// Step 2: Remove ".funcN" suffix, if it exists
+// 	if funcSuffix := strings.LastIndex(fullName, ".func"); funcSuffix != -1 {
+// 		fullName = fullName[:funcSuffix]
+// 	}
+
+// 	// Step 3: Handle struct method pattern (*StructName).Method
+// 	if structMethodIdx := strings.Index(fullName, ")."); structMethodIdx != -1 {
+// 		// Extract the part before ")." and after the last dot (e.g., "*GitHubTokenTransport")
+// 		lastDotBeforeStruct := strings.LastIndex(fullName[:structMethodIdx], ".")
+// 		fullName = fullName[:lastDotBeforeStruct] + fullName[structMethodIdx+2:]
+// 	}
+
+// 	return fullName
+// }
 
 // SetSpanAttributes sets attributes on the current span based on the LogConfig
 func (l *logger) SetSpanAttributes(spanName string) {
@@ -186,7 +197,7 @@ func (l *logger) SetSpanAttributes(spanName string) {
 			continue
 		}
 
-		nullifyContext.Span.SetAttributes(attribute.String(snakeToCamel(jsonKey), field.String()))
+		nullifyContext.Span.SetAttributes(attribute.String(jsonKey, field.String()))
 	}
 }
 
@@ -207,7 +218,7 @@ func (l *logger) setStructAttributes(v reflect.Value) {
 			continue
 		}
 		if field.String() != "" {
-			nullifyContext.Span.SetAttributes(attribute.String(snakeToCamel(jsonKey), field.String()))
+			nullifyContext.Span.SetAttributes(attribute.String(jsonKey, field.String()))
 		}
 	}
 }


### PR DESCRIPTION
## Description

More refining the the logging package.

sample log would be
from
```
ctx, span := tracer.FromContext(ctx).Start(ctx, "webhooks.github.HandleGithubCheckSuite")
defer span.End()

ctx, span = logger.SetMetdataForLogsAndTraces(ctx, span, map[string]string{
  "repository_name":  payload.Repository.Name,
  "repository_owner": strconv.FormatInt(payload.Repository.Owner.ID, 10),
  "repository_id":    strconv.FormatInt(payload.Repository.ID, 10),
  "installation_id":  strconv.FormatInt(payload.Installation.ID, 10),
  "app_id":           strconv.FormatInt(payload.CheckSuite.App.ID, 10),
  "action":           payload.Action,
})
defer span.End()
```

```
ctx, nullifyContext := logger.GetNullifyContext(ctx)
nullifyContext.LogConfig.Repository = logger.Repository{
  Name:           payload.Repository.Name,
  Owner:          payload.Repository.Owner.Login,
  ID:             strconv.FormatInt(payload.Repository.Owner.ID, 10),
  InstallationID: strconv.FormatInt(payload.Installation.ID, 10),
  AppID:          strconv.FormatInt(payload.CheckSuite.App.ID, 10),
  Action:         payload.Action,
}
logger.L(ctx).SetSpanAttributes("webhooks.github.HandleGithubCheckSuite")
defer nullifyContext.TraceConfig.Span.End()
```

-> Improved Go Efficiency, as context.Value gets updated once instead of each field getting its own update