### PR TITLE
fix: populate OTel resource attributes from env var

### DIFF
--- a/pkg/logger/configure.go
+++ b/pkg/logger/configure.go
@@ -134,6 +134,7 @@ func configureOTel(ctx context.Context, scopeName string) (context.Context, erro
 			semconv.ServiceVersion(Version),
 		),
 		resource.WithSchemaURL(semconv.SchemaURL),
+		resource.WithFromEnv(),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Description

`resource.New()` in `configureOTel()` was missing `resource.WithFromEnv()`, so resource attributes set via `OTEL_RESOURCE_ATTRIBUTES` (including `nul.deployment_id` and `deployment.environment`) were never attached to the OTel resource.

This meant they appeared on `target_info` (resource metadata) but not on any application metric (`nul_pipeline_event_total`, `nul_scan_duration_seconds`, etc.), making per-customer metric queries impossible.

**Impact**: Once deployed, all `nul_*` metrics will gain `nul_deployment_id` as a label, enabling per-customer alerting (e.g. pipeline volume drop/spike alerts) and dashboarding.

## Test Plan

- [x] `go build ./...` passes
- [x] `go test ./pkg/logger/... -short` passes
- [ ] After deploy to one service, verify `nul_deployment_id` appears on application metrics in Prometheus (not just `target_info`)
- [ ] Verify with: `group by (nul_deployment_id) (nul_pipeline_event_total{deployment_environment="prod", nul_deployment_id!=""})`

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have checked for redundant or commented out code
- [x] I have made corresponding changes to the documentation
- [x] I have added any appropriate tests